### PR TITLE
Remove superfluous private clause

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -2321,8 +2321,6 @@ class CSV
     chunks.map { |chunk| chunk.encode(@encoding.name) }.join('')
   end
 
-  private
-
   #
   # Returns the encoding of the internal IO object or the +default+ if the
   # encoding cannot be determined.


### PR DESCRIPTION
This last `private` is not needed since we it was added before.