### PR TITLE
Add the ability to delete multiple columns

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -807,20 +807,18 @@ class CSV
     end
 
     #
-    # Removes and returns the indicated columns or row.  In the default mixed
+    # Removes and returns the indicated columns or rows.  In the default mixed
     # mode indices refer to rows and everything else is assumed to be a column
-    # header.  Use by_col!() or by_row!() to force the lookup.
+    # headers.  Use by_col!() or by_row!() to force the lookup.
     #
-    def delete(index_or_header)
-      if index_or_header.is_a? Array # by array of headers
-        index_or_header.each do |element|
-          @table.map { |row| row.delete(element) }
+    def delete(*indexes_or_headers)
+      indexes_or_headers.map do |index_or_header|
+        if @mode == :row or  # by index
+          (@mode == :col_or_row and index_or_header.is_a? Integer)
+          @table.delete_at(index_or_header)
+        else                 # by header      
+          @table.map { |row| row.delete(index_or_header).last }  
         end
-      elsif @mode == :row or  # by index
-         (@mode == :col_or_row and index_or_header.is_a? Integer)
-        @table.delete_at(index_or_header)
-      else                    # by header
-        @table.map { |row| row.delete(index_or_header).last }
       end
     end
 

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -807,15 +807,19 @@ class CSV
     end
 
     #
-    # Removes and returns the indicated column or row.  In the default mixed
+    # Removes and returns the indicated columns or row.  In the default mixed
     # mode indices refer to rows and everything else is assumed to be a column
     # header.  Use by_col!() or by_row!() to force the lookup.
     #
     def delete(index_or_header)
-      if @mode == :row or  # by index
+      if index_or_header.is_a? Array # by array of headers
+        index_or_header.each do |element|
+          @table.map { |row| row.delete(element) }
+        end
+      elsif @mode == :row or  # by index
          (@mode == :col_or_row and index_or_header.is_a? Integer)
         @table.delete_at(index_or_header)
-      else                 # by header
+      else                    # by header
         @table.map { |row| row.delete(index_or_header).last }
       end
     end

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -322,11 +322,14 @@ class TestCSV::Table < TestCSV
     # delete a col
     assert_equal(@rows.map { |row| row["A"] }, @table.delete("A"))
 
+    # delete an array of cols
+    assert_equal(["B"], @table.delete(["B"]))
+
     # verify resulting table
     assert_equal(<<-END_RESULT.gsub(/^\s+/, ""), @table.to_csv)
-    B,C
-    2,3
-    8,9
+    C
+    3
+    9
     END_RESULT
   end
 

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -317,14 +317,11 @@ class TestCSV::Table < TestCSV
     ### Mixed Mode ###
     ##################
     # delete a row
-    assert_equal(@rows[1], @table.delete(1))
+    assert_equal([@rows[1]], @table.delete(1))
 
-    # delete a col
-    assert_equal(@rows.map { |row| row["A"] }, @table.delete("A"))
-
-    # delete an array of cols
-    assert_equal(["B"], @table.delete(["B"]))
-
+    # delete cols
+    assert_equal([@rows.map { |row| row["A"] }, @rows.map { |row| row["B"] }], @table.delete("A", "B"))
+    
     # verify resulting table
     assert_equal(<<-END_RESULT.gsub(/^\s+/, ""), @table.to_csv)
     C
@@ -339,8 +336,8 @@ class TestCSV::Table < TestCSV
     ###################
     @table.by_col!
 
-    assert_equal(@rows.map { |row| row[0] }, @table.delete(0))
-    assert_equal(@rows.map { |row| row["C"] }, @table.delete("C"))
+    assert_equal([@rows.map { |row| row[0] }], @table.delete(0))
+    assert_equal([@rows.map { |row| row["C"] }], @table.delete("C"))
 
     # verify resulting table
     assert_equal(<<-END_RESULT.gsub(/^\s+/, ""), @table.to_csv)
@@ -357,7 +354,7 @@ class TestCSV::Table < TestCSV
     ################
     @table.by_row!
 
-    assert_equal(@rows[1], @table.delete(1))
+    assert_equal([@rows[1]], @table.delete(1))
     assert_raise(TypeError) { @table.delete("C") }
 
     # verify resulting table
@@ -371,7 +368,7 @@ class TestCSV::Table < TestCSV
   def test_delete_with_blank_rows
     data = "col1,col2\nra1,ra2\n\nrb1,rb2"
     table = CSV.parse(data, :headers => true)
-    assert_equal(["ra2", nil, "rb2"], table.delete("col2"))
+    assert_equal([["ra2", nil, "rb2"]], table.delete("col2"))
   end
 
   def test_delete_if_row


### PR DESCRIPTION
When I was working with some statistics using Ruby/csv, I discovered that the mechanism for deleting columns is very peculiar in Ruby and we can't easily just delete more than 1 column.
We can do it like this (DRY):
```ruby
csv_table.delete("PassengerId")
csv_table.delete("Survived")
csv_table.delete("Name")
csv_table.to_csv
```

Or like this (will destroy csv structure -> Array of Arrays):
```ruby
datus = CSV.readlines('titanic.csv', headers:true).map{|row| row.values_at('PassengerId','SibSp') }
```

And finally the best working way for me:
```ruby
to_del = ["Name", "Ticket"]
csv_table = datus.by_col!.delete_if { |name, values| !to_del.include? name}
```
But I think it should work easily like this:
```ruby
to_del = ["Name", "Ticket"]
data.delete(to_del)
```
So I rewrote method a little and added this functionality. If you have any ideas: create another ```delete_columns``` method or maybe better ways to fast delete columns, I will be glad to hear it:)