### PR TITLE
fix generate with a string

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1164,8 +1164,8 @@ class CSV
   def self.generate(str=nil, **options)
     # add a default empty String, if none was given
     if str
-      io = StringIO.new(str)
-      io.seek(0, IO::SEEK_END)
+      str = StringIO.new(str)
+      str.seek(0, IO::SEEK_END)
     else
       encoding = options[:encoding]
       str      = String.new

--- a/test/csv/test_interface.rb
+++ b/test/csv/test_interface.rb
@@ -161,6 +161,9 @@ class TestCSV::Interface < TestCSV
       assert_equal(csv, csv << ["last", %Q{"row"}])
     end
     assert_equal(%Q{1,2,3\n4,,5\nlast,"""row"""\n}, str)
+
+    out = CSV.generate("test") { |csv| csv << ["row"] }
+    assert_equal("testrow\n", out)
   end
 
   def test_generate_line


### PR DESCRIPTION
ruby 2.5 regression

https://github.com/ruby/ruby/commit/a983fc502288776cde7b97519c7ddab7aa2ca6b9

expected
```ruby
CSV.generate("test") { |csv| csv << ["row"] }
=> testrow\n
```

actual
```ruby
CSV.generate("test") { |csv| csv << ["row"] }
=> row\n
```

http://ruby-doc.org/stdlib-2.5.0/libdoc/csv/rdoc/CSV.html#method-c-generate

> This method wraps a String you provide, or an empty default String, in a CSV object which is passed to the provided block. You can use the block to append CSV rows to the String and when the block exits, the final String will be returned.