### PR TITLE
[Feature] Add dig method to CSV::Table and CSV::Row

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -548,7 +548,7 @@ class CSV
     alias_method :to_s, :to_csv
 
     #
-    # Extracts the nested value specified by the sequence of name objects by calling dig at each step,
+    # Extracts the nested value specified by the sequence of +index+ or +header+ objects by calling dig at each step,
     # returning nil if any intermediate step is nil.
     #
     def dig(index_or_header, *indexes)
@@ -923,7 +923,7 @@ class CSV
     alias_method :to_s, :to_csv
 
     #
-    # Extracts the nested value specified by the sequence of name objects by calling dig at each step,
+    # Extracts the nested value specified by the sequence of +index+ or +header+ objects by calling dig at each step,
     # returning nil if any intermediate step is nil.
     #
     def dig(index_or_header, *index_or_headers)

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -547,6 +547,21 @@ class CSV
     end
     alias_method :to_s, :to_csv
 
+    #
+    # Extracts the nested value specified by the sequence of name objects by calling dig at each step,
+    # returning nil if any intermediate step is nil.
+    #
+    def dig(index_or_header, *index_or_headers)
+      value = field(index_or_header)
+      if value.nil?
+        nil
+      elsif index_or_headers.empty?
+        value
+      else
+        value.dig(*index_or_headers)
+      end
+    end
+
     # A summary of fields, by header, in an ASCII compatible String.
     def inspect
       str = ["#<", self.class.to_s]
@@ -902,6 +917,21 @@ class CSV
       return array.join('')
     end
     alias_method :to_s, :to_csv
+
+    #
+    # Extracts the nested value specified by the sequence of name objects by calling dig at each step,
+    # returning nil if any intermediate step is nil.
+    #
+    def dig(index_or_header, *index_or_headers)
+      value = send(:[], index_or_header)
+      if value.nil?
+        nil
+      elsif index_or_headers.empty?
+        value
+      else
+        value.dig(*index_or_headers)
+      end
+    end
 
     # Shows the mode and size of this table in a US-ASCII String.
     def inspect

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -551,14 +551,14 @@ class CSV
     # Extracts the nested value specified by the sequence of name objects by calling dig at each step,
     # returning nil if any intermediate step is nil.
     #
-    def dig(index_or_header, *index_or_headers)
+    def dig(index_or_header, *indexes)
       value = field(index_or_header)
       if value.nil?
         nil
-      elsif index_or_headers.empty?
+      elsif indexes.empty?
         value
       else
-        value.dig(*index_or_headers)
+        value.dig(*indexes)
       end
     end
 

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -558,7 +558,11 @@ class CSV
       elsif indexes.empty?
         value
       else
-        value.dig(*indexes)
+        begin
+          value.dig(*indexes)
+        rescue NoMethodError => e
+          raise TypeError, "#{e.args.first.class} does not have #dig method"
+        end
       end
     end
 
@@ -929,7 +933,11 @@ class CSV
       elsif index_or_headers.empty?
         value
       else
-        value.dig(*index_or_headers)
+        begin
+          value.dig(*index_or_headers)
+        rescue NoMethodError => e
+          raise TypeError, "#{e.args.first.class} does not have #dig method"
+        end  
       end
     end
 

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -923,7 +923,7 @@ class CSV
     # returning nil if any intermediate step is nil.
     #
     def dig(index_or_header, *index_or_headers)
-      value = send(:[], index_or_header)
+      value = self[index_or_header]
       if value.nil?
         nil
       elsif index_or_headers.empty?

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -388,5 +388,10 @@ class TestCSV::Row < TestCSV
     # if missing
     assert_nil(@row.dig("Missing"))
     assert_nil(@row.dig(100))
+
+    # if multiple arguments
+    # following value does not have #dig method
+    assert_raise(TypeError) { @row.dig(1, "A") }
+    assert_raise(TypeError) { @row.dig("B", 0) }
   end
 end

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -390,6 +390,16 @@ class TestCSV::Row < TestCSV
     assert_nil(@row.dig(100))
 
     # if multiple arguments
+    @row << ["foo", ["bar", ["baz", 4]]]
+
+    # by index
+    assert_equal("bar", @row.dig(5, 0))
+    assert_equal("baz", @row.dig(5, 1, 0))
+
+    # by header
+    assert_equal("bar", @row.dig("foo", 0))
+    assert_equal(4, @row.dig("foo", 1, 1))
+
     # following value does not have #dig method
     assert_raise(TypeError) { @row.dig(1, "A") }
     assert_raise(TypeError) { @row.dig("B", 0) }

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -377,4 +377,16 @@ class TestCSV::Row < TestCSV
     r = @row == []
     assert_equal false, r
   end
+
+  def test_dig
+    # by index
+    assert_equal(2, @row.dig(1))
+
+    # by header
+    assert_equal(2, @row.dig("B"))
+
+    # if missing
+    assert_nil(@row.dig("Missing"))
+    assert_nil(@row.dig(100))
+  end
 end

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -510,10 +510,12 @@ class TestCSV::Table < TestCSV
     # by cell, row then col
     assert_equal(2, @table.dig(0, 1))
     assert_equal(6, @table.dig(1, "C"))
+    assert_raise(TypeError) { @table.dig(0, 1, 0) } # following value does not have #dig method
 
     # by cell, col then row
     assert_equal(5, @table.dig("B", 1))
     assert_equal(9, @table.dig("C", 2))
+    assert_raise(TypeError) { @table.dig("B", 1, 0) } # following value does not have #dig method
 
     ###################
     ### Column Mode ###

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -494,4 +494,51 @@ class TestCSV::Table < TestCSV
                  @table.inspect.encoding],
             "inspect() was not ASCII compatible." )
   end
+
+  def test_dig
+    ##################
+    ### Mixed Mode ###
+    ##################
+    # by row
+    assert_equal(@rows[0], @table.dig(0))
+    assert_nil(@table.dig(100))  # empty row
+
+    # by col
+    @rows.first.headers.each do |header|
+      assert_equal(@rows.map { |row| row[header] }, @table[header])
+    end
+    assert_equal([nil] * @rows.size, @table["Z"])  # empty col
+
+    # by cell, row then col
+    assert_equal(2, @table.dig(0, 1))
+    assert_equal(6, @table.dig(1, "C"))
+
+    # by cell, col then row
+    assert_equal(5, @table.dig("B", 1))
+    assert_equal(9, @table.dig("C", 2))
+
+    ###################
+    ### Column Mode ###
+    ###################
+    @table.by_col!
+
+    assert_equal([2, 5, 8], @table.dig(1))
+    assert_equal([2, 5, 8], @table.dig("B"))
+
+    # by cell, col then row
+    assert_equal(5, @table.dig("B", 1))
+    assert_equal(9, @table.dig("C", 2))
+
+    ################
+    ### Row Mode ###
+    ################
+    @table.by_row!
+
+    assert_equal(@rows[1], @table.dig(1))
+    assert_raise(TypeError) { @table.dig("B") }
+
+    # by cell, row then col
+    assert_equal(2, @table.dig(0, 1))
+    assert_equal(6, @table.dig(1, "C"))
+  end
 end

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -504,10 +504,8 @@ class TestCSV::Table < TestCSV
     assert_nil(@table.dig(100))  # empty row
 
     # by col
-    @rows.first.headers.each do |header|
-      assert_equal(@rows.map { |row| row[header] }, @table[header])
-    end
-    assert_equal([nil] * @rows.size, @table["Z"])  # empty col
+    assert_equal([2, 5, 8], @table.dig("B"))
+    assert_equal([nil] * @rows.size, @table.dig("Z"))  # empty col
 
     # by cell, row then col
     assert_equal(2, @table.dig(0, 1))

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -540,5 +540,19 @@ class TestCSV::Table < TestCSV
     # by cell, row then col
     assert_equal(2, @table.dig(0, 1))
     assert_equal(6, @table.dig(1, "C"))
+
+    ########################################
+    ### Test for three or more arguments ###
+    ########################################
+    @table.by_col_or_row!
+    @table << ["foo", ["bar", ["baz", 4]]]
+
+    # by cell, row then col
+    assert_equal("bar", @table.dig(3, "B", 0))
+    assert_equal("baz", @table.dig(3, "B", 1, 0))
+
+    # by cell, col then row
+    assert_equal("bar", @table.dig("B", 3, 0))
+    assert_equal(4, @table.dig("B", 3, 1, 1))
   end
 end


### PR DESCRIPTION
## Abstract
- This PR implements `dig` method to CSV::Table and CSV::Row

## Background
- Already, Array, Hash and Struct class has `dig` method from Ruby 2.3, but CSV::Table and CSV::Row not has this method.
- I would like to use `#dig` for CSV::Table or nested arrays (or hashes) with CSV::Row without distinction.

## Usage

```rb
arr_of_arrs = CSV.parse("first,second,third\n1,2,3\n", headers: true)

# as single value
arr_or_arrs.dig(0) # row mode
=> #<CSV::Row "first":"1" "second":"2" "third":"3">
arr_of_arrs.dig("first") # col mode
=> ["1"]

# as nested values
arr_of_arrs.dig(0, "first")
=> "1"
arr_of_arrs.dig("first", 0)
=> "1"
```