### PR TITLE
improve by Ruby 2.5 Lasy Proc

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1310,8 +1310,9 @@ class CSV
   def self.parse(*args, &block)
     csv = new(*args)
 
-    return csv.each(&block) if block_given? # slurp contents, if no block is given
+    return csv.each(&block) if block_given?
 
+    # slurp contents, if no block is given
     begin
       csv.read
     ensure

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -839,7 +839,7 @@ class CSV
       else                                      # by header
         deleted = []
         headers.each do |header|
-          deleted << delete(header) if block[[header, self[header]]]
+          deleted << delete(header) if yield([header, self[header]])
         end
       end
 
@@ -861,7 +861,7 @@ class CSV
       return enum_for(__method__) { @mode == :col ? headers.size : size } unless block_given?
 
       if @mode == :col
-        headers.each { |header| block[[header, self[header]]] }
+        headers.each { |header| yield([header, self[header]]) }
       else
         @table.each(&block)
       end

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -434,7 +434,7 @@ class CSV
     # If no block is given, an Enumerator is returned.
     #
     def delete_if(&block)
-      block or return enum_for(__method__) { size }
+      return enum_for(__method__) { size } unless block_given?
 
       @row.delete_if(&block)
 
@@ -513,7 +513,7 @@ class CSV
     # Support for Enumerable.
     #
     def each(&block)
-      block or return enum_for(__method__) { size }
+      return enum_for(__method__) { size } unless block_given?
 
       @row.each(&block)
 
@@ -832,7 +832,7 @@ class CSV
     # If no block is given, an Enumerator is returned.
     #
     def delete_if(&block)
-      block or return enum_for(__method__) { @mode == :row or @mode == :col_or_row ? size : headers.size }
+      return enum_for(__method__) { @mode == :row or @mode == :col_or_row ? size : headers.size } unless block_given?
 
       if @mode == :row or @mode == :col_or_row  # by index
         @table.delete_if(&block)
@@ -858,7 +858,7 @@ class CSV
     # If no block is given, an Enumerator is returned.
     #
     def each(&block)
-      block or return enum_for(__method__) { @mode == :col ? headers.size : size }
+      return enum_for(__method__) { @mode == :col ? headers.size : size } unless block_given?
 
       if @mode == :col
         headers.each { |header| block[[header, self[header]]] }
@@ -1137,7 +1137,7 @@ class CSV
   # but transcode it to UTF-8 before CSV parses it.
   #
   def self.foreach(path, **options, &block)
-    return to_enum(__method__, path, options) unless block
+    return to_enum(__method__, path, options) unless block_given?
     open(path, options) do |csv|
       csv.each(&block)
     end
@@ -1309,7 +1309,7 @@ class CSV
   #
   def self.parse(*args, &block)
     csv = new(*args)
-    if block.nil?  # slurp contents, if no block is given
+    unless block_given? # slurp contents, if no block is given
       begin
         csv.read
       ensure

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1309,14 +1309,13 @@ class CSV
   #
   def self.parse(*args, &block)
     csv = new(*args)
-    unless block_given? # slurp contents, if no block is given
-      begin
-        csv.read
-      ensure
-        csv.close
-      end
-    else           # or pass each row to a provided block
-      csv.each(&block)
+
+    return csv.each(&block) if block_given? # slurp contents, if no block is given
+
+    begin
+      csv.read
+    ensure
+      csv.close
     end
   end
 


### PR DESCRIPTION
Ruby2.5 has the advantage to use `block_given?`.

https://bugs.ruby-lang.org/issues/14045

```
$ ruby -v
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin17]

$ cat block_given.rb
def use_if_block(&block)
  return nil if block
end

def use_block_given(&block)
  return nil if block_given?
end

require 'benchmark'
Benchmark.bm(10){|x|
  x.report("use_if_block"){
    100000.times{
      use_if_block { 1 }
    }
  }
  x.report("use_block_given") {
    100000.times{
      use_block_given { 1 }
    }
  }
}

$ ruby block_given.rb
                 user     system      total        real
use_if_block  0.053502   0.001040   0.054542 (  0.054878)
use_block_given  0.010321   0.000023   0.010344 (  0.010386)
```