### PR TITLE
Fix Unknown Encoding issue

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1569,15 +1569,10 @@ class CSV
 
     # create the IO object we will read from
     @io = data.is_a?(String) ? StringIO.new(data) : data
-    # honor the IO encoding if we can, otherwise default to ASCII-8BIT
-    internal_encoding = Encoding.find(internal_encoding) if internal_encoding
-    external_encoding = Encoding.find(external_encoding) if external_encoding
-    if encoding
-      encoding, = encoding.split(":", 2) if encoding.is_a?(String)
-      encoding = Encoding.find(encoding)
-    end
-    @encoding = raw_encoding(nil) || internal_encoding || encoding ||
-                Encoding.default_internal || Encoding.default_external
+
+    # gets the encoding we will use
+    @encoding = get_encoding(internal_encoding, external_encoding, encoding)
+
     #
     # prepare for building safe regular expressions in the target encoding,
     # if we can transcode the needed characters
@@ -2039,6 +2034,21 @@ class CSV
   end
 
   private
+
+  def get_encoding(internal_encoding, external_encoding, encoding)
+    if (enc = raw_encoding(nil))
+      enc
+    else
+      enc = Encoding.find(internal_encoding) if internal_encoding
+      if encoding
+        encoding, = encoding.split(":", 2) if encoding.is_a?(String)
+        enc ||= Encoding.find(encoding)
+      end
+      enc ||= Encoding.find(external_encoding) if external_encoding
+
+      enc || Encoding.default_internal || Encoding.default_external
+    end
+  end
 
   #
   # Stores the indicated separators for later use.

--- a/test/csv/test_interface.rb
+++ b/test/csv/test_interface.rb
@@ -93,16 +93,26 @@ class TestCSV::Interface < TestCSV
   end
 
   def test_read_and_readlines
-    assert_equal( @expected,
-                  CSV.read(@path, col_sep: "\t", row_sep: "\r\n") )
-    assert_equal( @expected,
-                  CSV.readlines(@path, col_sep: "\t", row_sep: "\r\n") )
+    assert_equal(
+      @expected,
+      CSV.read(@path, col_sep: "\t", row_sep: "\r\n")
+    )
 
+    assert_equal(
+      @expected,
+      CSV.read(@path, col_sep: "\t", row_sep: "\r\n", encoding: "bom|utf-8")
+    )
+
+    assert_equal(
+      @expected,
+      CSV.readlines(@path, col_sep: "\t", row_sep: "\r\n")
+    )
 
     data = CSV.open(@path, col_sep: "\t", row_sep: "\r\n") do |csv|
       csv.read
     end
     assert_equal(@expected, data)
+
     data = CSV.open(@path, col_sep: "\t", row_sep: "\r\n") do |csv|
       csv.readlines
     end


### PR DESCRIPTION
This fixes #23 and makes the following modification:

+ @encoding can be set to external_encoding. Previously, it ignored external_encoding.

To me, it looks like the encoding option is usually ignored. `CSV.read|CSV.open` will use the encoding options provided by a user if:

1. the user passes in an `IO`-like object where `respond_to?(:internal_encoding) == true && (io.internal_encoding || io.external_encoding).nil?`
2. the user passes in a `StringIO`-like object where the string has no encoding.
3. the user passes in an `IO`-like object where`respond_to?(:encoding) == true && io.encoding.nil?`

As far as I know, the above situations can only occur if the user is passing in a custom `IO` object
that doesn't have encoding information. This analysis is based off of the `raw_encoding` method

```ruby
def raw_encoding(default = Encoding::ASCII_8BIT)
  if @io.respond_to? :internal_encoding
    @io.internal_encoding || @io.external_encoding
  elsif @io.is_a? StringIO
    @io.string.encoding
  elsif @io.respond_to? :encoding
    @io.encoding
  else
    default
  end
end
```