### PR TITLE
Update CVS documentation

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -101,68 +101,117 @@ require_relative "csv/row"
 # tools to enable you to read and write to and from Strings or IO objects, as
 # needed.
 #
-# == Reading
+# The most generic interface of a class is:
 #
-# === From a File
+#    csv = CSV.new(string_or_io, **options)
 #
-# ==== A Line at a Time
+#    # Reading: IO object should be open for read
+#    csv.read # => array of rows
+#    # or
+#    csv.each do |row|
+#      # ...
+#    end
+#    # or
+#    row = csv.shift
 #
-#   CSV.foreach("path/to/file.csv") do |row|
-#     # use row here...
+#    # Writing: IO object should be open for write
+#    csv << row
+#
+# There are several specialized class methods for one-statement reading or writing,
+# described in the Specialized Methods section.
+#
+# If a String passed into ::new, it is internally wrapped into a StringIO object.
+#
+# +options+ can be used for specifying the particular CSV flavor (column
+# separators, row separators, value quoting and so on), and for data conversion,
+# see Data Conversion section for the description of the latter.
+#
+# == Specialized Methods
+#
+# === Reading
+#
+#   # From a file: all at once
+#   arr_of_rows = CSV.read("path/to/file.csv", **options)
+#   # iterator-style:
+#   CSV.foreach("path/to/file.csv", **options) do |row|
+#     # ...
 #   end
 #
-# ==== All at Once
-#
-#   arr_of_arrs = CSV.read("path/to/file.csv")
-#
-# === From a String
-#
-# ==== A Line at a Time
-#
-#   CSV.parse("CSV,data,String") do |row|
-#     # use row here...
+#   # From a string
+#   arr_of_rows = CSV.parse("CSV,data,String", **options)
+#   # or
+#   CSV.parse("CSV,data,String", **options) do |row|
+#     # ...
 #   end
 #
-# ==== All at Once
+# === Writing
 #
-#   arr_of_arrs = CSV.parse("CSV,data,String")
-#
-# == Writing
-#
-# === To a File
-#
+#   # To a file
 #   CSV.open("path/to/file.csv", "wb") do |csv|
 #     csv << ["row", "of", "CSV", "data"]
 #     csv << ["another", "row"]
 #     # ...
 #   end
 #
-# === To a String
-#
+#   # To a String
 #   csv_string = CSV.generate do |csv|
 #     csv << ["row", "of", "CSV", "data"]
 #     csv << ["another", "row"]
 #     # ...
 #   end
 #
-# == Convert a Single Line
+# === Shortcuts
 #
+#   # Core extensions for converting one line
 #   csv_string = ["CSV", "data"].to_csv   # to CSV
 #   csv_array  = "CSV,String".parse_csv   # from CSV
 #
-# == Shortcut Interface
-#
+#   # CSV() method
 #   CSV             { |csv_out| csv_out << %w{my data here} }  # to $stdout
 #   CSV(csv = "")   { |csv_str| csv_str << %w{my data here} }  # to a String
 #   CSV($stderr)    { |csv_err| csv_err << %w{my data here} }  # to $stderr
 #   CSV($stdin)     { |csv_in|  csv_in.each { |row| p row } }  # from $stdin
 #
-# == Advanced Usage
+# == Data Conversion
 #
-# === Wrap an IO Object
+# === CSV with headers
 #
-#   csv = CSV.new(io, options)
-#   # ... read (with gets() or each()) from and write (with <<) to csv here ...
+# CSV allows to specify column names of CSV file, whether they are in data, or
+# provided separately. If headers specified, reading methods return an instance
+# of CSV::Table, consisting of CSV::Row.
+#
+#   # Headers are part of data
+#   data = CSV.parse(<<~ROWS, headers: true)
+#     Name,Department,Salary
+#     Bob,Engeneering,1000
+#     Jane,Sales,2000
+#     John,Management,5000
+#   ROWS
+#
+#   data.class      #=> CSV::Table
+#   data.first      #=> #<CSV::Row "Name":"Bob" "Department":"Engeneering" "Salary":"1000">
+#   data.first.to_h #=> {"Name"=>"Bob", "Department"=>"Engeneering", "Salary"=>"1000"}
+#
+#   # Headers provided by developer
+#   data = CSV.parse('Bob,Engeneering,1000', headers: %i[name department salary])
+#   data.first      #=> #<CSV::Row name:"Bob" department:"Engeneering" salary:"1000">
+#
+# === Typed data reading
+#
+# CSV allows to provide a set of data _converters_ e.g. transformations to try on input
+# data. Converter could be a symbol from CSV::Converters constant's keys, or lambda.
+#
+#   # Without any converters:
+#   CSV.parse('Bob,2018-03-01,100')
+#   #=> [["Bob", "2018-03-01", "100"]]
+#
+#   # With built-in converters:
+#   CSV.parse('Bob,2018-03-01,100', converters: %i[numeric date])
+#   #=> [["Bob", #<Date: 2018-03-01>, 100]]
+#
+#   # With custom converters:
+#   CSV.parse('Bob,2018-03-01,100', converters: [->(v) { Time.parse(v) rescue v }])
+#   #=> [["Bob", 2018-03-01 00:00:00 +0200, "100"]]
 #
 # == CSV and Character Encodings (M17n or Multilingualization)
 #


### PR DESCRIPTION
Problems of the "intro" section of [current documentation](http://ruby-doc.org/stdlib-2.5.0/libdoc/csv/rdoc/CSV.html) I am trying to solve:

* It does not provide a generic overview of the class usage, diving straight into particular examples;
* The overall structure, with a lot of headers and subheaders, which separate 1-2 line sections, is hard to read
* The large part of functionality (data conversion and usage of headers to obtain `CSV::Table`/`CSV::Row`) is not mentioned in the intro at all. I constantly see students, juniors or even middle devs that use the library a lot yet still unaware of those parts of functionality.