### PR TITLE
Add Row#each_pair

### DIFF
--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -313,6 +313,8 @@ class CSV
       self  # for chaining
     end
 
+    alias each_pair each
+
     #
     # Returns +true+ if this row contains the same headers and fields in the
     # same order as +other+.


### PR DESCRIPTION
Reason: `Row` tries to quack more-or-less like `Hash`, and `Hash` has `#each_pair`. A practical example where it matters:

```ruby
csv = CSV.parse('Bob,100', headers: %i[name salary])
OpenStruct.new(csv.first)
# NoMethodError: undefined method `each_pair' for #<CSV::Row name:"Bob" salary:"100">

# After this patch:
OpenStruct.new(csv.first)
#=> #<OpenStruct name="Bob", salary="100">
```