### PR TITLE
Add news for v1.0.2

### DIFF
--- a/news.md
+++ b/news.md
@@ -1,5 +1,68 @@
 # News
 
+## 1.0.2 - 2018-05-03
+
+### Improvements
+
+  * Split file for CSV::VERSION
+
+  * Code cleanup: Split csv.rb into a more manageable structure
+    [GitHub#19][Patch by Espartaco Palma]
+    [GitHub#20][Patch by Steven Daniels]
+
+  * Use CSV::MalformedCSVError for invalid encoding line
+    [GitHub#26][Reported by deepj]
+
+  * Support implicit Row <-> Array conversion
+    [Bug #10013][ruby-core:63582][Reported by Dawid Janczak]
+
+  * Update class docs
+    [GitHub#32][Patch by zverok]
+
+  * Add `Row#each_pair`
+    [GitHub#33][Patch by zverok]
+
+  * Improve CSV performance
+    [GitHub#30][Patch by Watson]
+
+  * Add :nil_value and :empty_value option
+
+### Fixes
+
+  * Fix a bug that "bom|utf-8" doesn't work
+    [GitHub#23][Reported by Pavel Lobashov]
+
+  * `CSV::Row#to_h`, `#to_hash`: uses the same value as `Row#[]`
+    [Bug #14482][Reported by tomoya ishida]
+
+  * Make row separator detection more robust
+    [GitHub#25][Reported by deepj]
+
+  * Fix a bug that too much separator when col_sep is `" "`
+    [Bug #8784][ruby-core:63582][Reported by Sylvain Laperche]
+
+### Thanks
+
+  * Espartaco Palma
+
+  * Steven Daniels
+
+  * deepj
+
+  * Dawid Janczak
+
+  * zverok
+
+  * Watson
+
+  * Pavel Lobashov
+
+  * tomoya ishida
+
+  * Sylvain Laperche
+
+  * Ryunosuke Sato
+
 ## 1.0.1 - 2018-02-09
 
 ### Improvements


### PR DESCRIPTION
I updated `news.md` for preparing a new release.
From: https://github.com/ruby/csv/issues/23#issuecomment-385948683

@kou
I read [v1.0.1...d8d183d1](https://github.com/ruby/csv/compare/v1.0.1...d8d183d1) and listed the changes affected to csv gem users.
Is it enough as news?
If there are any missing infomation, please comment me what should be listed :-)

----

[Rendered](https://github.com/tricknotes/csv/blob/news-for-1.0.2/news.md)