### PR TITLE
Ensure nil rows create Row object with headers

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1232,7 +1232,7 @@ class CSV
           elsif @unconverted_fields
             return add_unconverted_fields(Array.new, Array.new)
           elsif @use_headers
-            return self.class::Row.new(Array.new, Array.new)
+            return self.class::Row.new(@headers, Array.new)
           else
             return Array.new
           end

--- a/test/csv/test_headers.rb
+++ b/test/csv/test_headers.rb
@@ -300,4 +300,20 @@ class TestCSV::Headers < TestCSV
       assert_instance_of(CSV::Row, row)
     end
   end
+
+  def test_nil_row_header_bug_fix
+    @data = <<-END_CSV.gsub(/^ +/, "")
+      A
+
+      1
+    END_CSV
+
+    csv = CSV.parse(@data, headers: true)
+
+    # ensure nil row creates Row object with headers
+    row = csv[0]
+    assert_instance_of(CSV::Row, row)
+    assert_equal(%w[A], row.headers)
+    assert_equal([nil], row.fields)
+  end
 end


### PR DESCRIPTION
### Issue
When parsing a CSV file with `headers: true` to receive `CSV::Row` objects, there is an issue if the file has only one field and nil values as rows. For example:

```
data = "email\n\nwritegracelee@gmail.com"

# returns []
CSV.parse(data, headers: true).first.headers
```

So if you are iterating through the `CSV::Row`s using the header to access the value, you can potentially run into unexpected behavior. For example:

```
data = "email\n\nwritegracelee@gmail.com"

CSV.parse(data, headers: true).each do |row|
  row.each do |field_name, value|
    if field_name == 'email'
      if valid_email?(value)
        valid_emails += 1
      else
        invalid_emails += 1
      end
    end
  end
end
```

Note that `valid_email?`, `valid_emails`, and `invalid_emails` are just for the example.

The current behavior will skip processing of the row with the nil value because the header is not set properly.

### Fix
Pass in headers as an argument to CSV::Row, even when row has only a nil value. This will ensure nil rows will create a CSV::Row object with headers.
