### PR TITLE
Support ruby core repository with gemspec

### DIFF
--- a/csv.gemspec
+++ b/csv.gemspec
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "lib/csv/version"
+begin
+  require_relative "lib/csv/version"
+rescue LoadError
+  require_relative "version"
+end
 
 Gem::Specification.new do |spec|
   spec.name          = "csv"

--- a/csv.gemspec
+++ b/csv.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/csv"
   spec.license       = "BSD-2-Clause"
 
-  spec.files         = Dir.glob("lib/**/*.rb")
+  spec.files         = ["lib/csv.rb", "lib/csv/table.rb", "lib/csv/core_ext/string.rb", "lib/csv/core_ext/array.rb", "lib/csv/row.rb", "lib/csv/version.rb"]
   spec.files         += ["README.md", "LICENSE.txt", "news.md"]
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"


### PR DESCRIPTION
This is the part of https://github.com/ruby/ruby/commit/60ebd4e26a1b6ed3ad11bade520db0a19e9be190.

The Ruby core repository uses the different structure with this upstream.  I added a fallback rescue block for the ruby core.