### PR TITLE
Enable headers-only file to get headers using 'headers: true' option

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1161,7 +1161,7 @@ class CSV
   def read
     rows = to_a
     if @use_headers
-      Table.new(rows)
+      Table.new(rows, @headers)
     else
       rows
     end

--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -16,6 +16,11 @@ class CSV
     # Construct a new CSV::Table from +array_of_rows+, which are expected
     # to be CSV::Row objects.  All rows are assumed to have the same headers.
     #
+    # The optional +headers+ parameter can be set to Array of headers.
+    # If headers aren't set, headers are fetched from CSV::Row objects.
+    # Otherwise, headers() method will return headers being set in
+    # headers arugument.
+    #
     # A CSV::Table object supports the following Array methods through
     # delegation:
     #
@@ -24,16 +29,15 @@ class CSV
     # * size()
     #
     def initialize(array_of_rows, headers=nil)
-      if headers.nil?
-        @table = array_of_rows
+      @table = array_of_rows
+      if headers
+        @headers = headers
+      else
         if @table.empty?
           @headers = []
         else
           @headers = @table.first.headers
         end
-      else
-        @headers = headers
-        @table = array_of_rows
       end
 
       @mode  = :col_or_row
@@ -301,8 +305,7 @@ class CSV
         @table.delete_if(&block)
       else                                      # by header
         deleted = []
-        initial_headers = headers
-        initial_headers.each do |header|
+        headers.each do |header|
           deleted << delete(header) if yield([header, self[header]])
         end
       end

--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -24,8 +24,18 @@ class CSV
     # * size()
     #
     def initialize(array_of_rows, headers=nil)
-      @headers = headers || []
-      @table = array_of_rows
+      if headers.nil?
+        @table = array_of_rows
+        if @table.empty?
+          @headers = []
+        else
+          @headers = @table.first.headers
+        end
+      else
+        @headers = headers
+        @table = array_of_rows
+      end
+
       @mode  = :col_or_row
     end
 
@@ -291,7 +301,7 @@ class CSV
         @table.delete_if(&block)
       else                                      # by header
         deleted = []
-        initial_headers = headers.dup
+        initial_headers = headers
         initial_headers.each do |header|
           deleted << delete(header) if yield([header, self[header]])
         end

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -16,12 +16,13 @@ class TestCSV::Table < TestCSV
     @rows  = [ CSV::Row.new(%w{A B C}, [1, 2, 3]),
                CSV::Row.new(%w{A B C}, [4, 5, 6]),
                CSV::Row.new(%w{A B C}, [7, 8, 9]) ]
-    @table = CSV::Table.new(@rows, %w{A B C})
+    @table = CSV::Table.new(@rows)
 
     @header_table = CSV::Table.new(
-      [CSV::Row.new(%w{A B C}, %w{A B C}, true)] + @rows,
-      %w{A B C}
+      [CSV::Row.new(%w{A B C}, %w{A B C}, true)] + @rows
     )
+    
+    @header_only_table = CSV::Table.new([], %w{A B C})
   end
 
   def test_initialze
@@ -65,8 +66,7 @@ class TestCSV::Table < TestCSV
   end
 
   def test_headers_only
-    t = CSV::Table.new([], %w{A B C})
-    assert_equal(%w[A B C], t.headers)
+    assert_equal(%w[A B C], @header_only_table.headers)
   end
 
   def test_index
@@ -210,7 +210,7 @@ A,B,C,Type,Index
 
   def test_set_by_col_with_header_row
     r  = [ CSV::Row.new(%w{X Y Z}, [97, 98, 99], true) ]
-    t = CSV::Table.new(r, %w{X Y Z})
+    t = CSV::Table.new(r)
     t.by_col!
     t['A'] = [42]
     assert_equal(['A'], t['A'])
@@ -477,6 +477,21 @@ A
     CSV
   end
 
+  def test_delete_headers_only
+    ###################
+    ### Column Mode ###
+    ###################
+    @header_only_table.by_col!
+
+    # delete by index
+    assert_equal([], @header_only_table.delete(0))
+    assert_equal(%w[B C], @header_only_table.headers)
+
+    # delete by header
+    assert_equal([], @header_only_table.delete("C"))
+    assert_equal(%w[B], @header_only_table.headers)
+  end
+
   def test_values_at
     ##################
     ### Mixed Mode ###
@@ -576,7 +591,7 @@ A
   end
 
   def test_dig_cell
-    table = CSV::Table.new([CSV::Row.new(["A"], [["foo", ["bar", ["baz"]]]])], ["A"])
+    table = CSV::Table.new([CSV::Row.new(["A"], [["foo", ["bar", ["baz"]]]])])
 
     # by row, col then cell
     assert_equal("foo", table.dig(0, "A", 0))
@@ -588,7 +603,7 @@ A
   end
 
   def test_dig_cell_no_dig
-    table = CSV::Table.new([CSV::Row.new(["A"], ["foo"])], ["A"])
+    table = CSV::Table.new([CSV::Row.new(["A"], ["foo"])])
 
     # by row, col then cell
     assert_raise(TypeError) do

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -16,10 +16,11 @@ class TestCSV::Table < TestCSV
     @rows  = [ CSV::Row.new(%w{A B C}, [1, 2, 3]),
                CSV::Row.new(%w{A B C}, [4, 5, 6]),
                CSV::Row.new(%w{A B C}, [7, 8, 9]) ]
-    @table = CSV::Table.new(@rows)
+    @table = CSV::Table.new(@rows, %w{A B C})
 
     @header_table = CSV::Table.new(
-      [CSV::Row.new(%w{A B C}, %w{A B C}, true)] + @rows
+      [CSV::Row.new(%w{A B C}, %w{A B C}, true)] + @rows,
+      %w{A B C}
     )
   end
 
@@ -61,6 +62,11 @@ class TestCSV::Table < TestCSV
   def test_headers_empty
     t = CSV::Table.new([])
     assert_equal Array.new, t.headers
+  end
+
+  def test_headers_only
+    t = CSV::Table.new([], %w{A B C})
+    assert_equal(%w[A B C], t.headers)
   end
 
   def test_index
@@ -204,7 +210,7 @@ A,B,C,Type,Index
 
   def test_set_by_col_with_header_row
     r  = [ CSV::Row.new(%w{X Y Z}, [97, 98, 99], true) ]
-    t = CSV::Table.new(r)
+    t = CSV::Table.new(r, %w{X Y Z})
     t.by_col!
     t['A'] = [42]
     assert_equal(['A'], t['A'])
@@ -570,7 +576,7 @@ A
   end
 
   def test_dig_cell
-    table = CSV::Table.new([CSV::Row.new(["A"], [["foo", ["bar", ["baz"]]]])])
+    table = CSV::Table.new([CSV::Row.new(["A"], [["foo", ["bar", ["baz"]]]])], ["A"])
 
     # by row, col then cell
     assert_equal("foo", table.dig(0, "A", 0))
@@ -582,7 +588,7 @@ A
   end
 
   def test_dig_cell_no_dig
-    table = CSV::Table.new([CSV::Row.new(["A"], ["foo"])])
+    table = CSV::Table.new([CSV::Row.new(["A"], ["foo"])], ["A"])
 
     # by row, col then cell
     assert_raise(TypeError) do


### PR DESCRIPTION
When trying to get headers from headers-only file using `headers: true` option, Table#headers method currently returns [].
So, I thought it's proper that Table#headers method return file's header in this case.

For example:
test.csv(headers-only file)
```
a,b,c
```

the previous behaviour
```
csv = CSV.read 'test.csv', {headers: true}
csv.headers
=> []
```

changed it as follows
```
csv = CSV.read 'test.csv', {headers: true}
csv.headers
=> ["a", "b", "c"]
```

I added an argument of headers to `Table.new` method because Table class should always has headers.