### PR TITLE
Removing branch on raw_encoding

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1738,8 +1738,6 @@ class CSV
   def raw_encoding(default = Encoding::ASCII_8BIT)
     if @io.respond_to? :internal_encoding
       @io.internal_encoding || @io.external_encoding
-    elsif @io.is_a? StringIO
-      @io.string.encoding
     elsif @io.respond_to? :encoding
       @io.encoding
     else


### PR DESCRIPTION
Turns out that `StringIO` objects responds to both `:internal_encoding` & `:external_encoding` so it doesn't execute that condition and the determinationof the encoding