### PR TITLE
Replace with flexible CSV parser

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1476,11 +1476,6 @@ class CSV
   def init_separators(col_sep, row_sep, quote_char, force_quotes)
     # store the selected separators
     @col_sep    = col_sep.to_s.encode(@encoding)
-    if @col_sep == " "
-      @col_sep_split_separator = "\s"
-    else
-      @col_sep_split_separator = @col_sep
-    end
     @row_sep    = row_sep # encode after resolving :auto
     @quote_char = quote_char.to_s.encode(@encoding)
 
@@ -1591,7 +1586,7 @@ class CSV
     # prebuild Regexps for faster parsing
     esc_row_sep = escape_re(@row_sep)
     esc_quote   = escape_re(@quote_char)
-    esc_col_sep = escape_re(@col_sep_split_separator)
+    esc_col_sep = escape_re(@col_sep)
     @parsers = {
       # for detecting parse errors
       col_sep: encode_re(esc_col_sep),

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1256,7 +1256,7 @@ class CSV
       scanner = StringScanner.new(parse)
       if scanner.eos?
         if in_extended_col
-          csv[-1] << @row_sep   # will be replaced with a @row_sep after the parts.each loop
+          csv[-1] << @row_sep
         else
           csv << nil
         end

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1284,10 +1284,9 @@ class CSV
               csv << +"#{@quote_char}#{liberal_parsing_string}#{@quote_char}"
               # e.g. '1,"\"2\"",3' #=> ["'1", "\"\\\"2\\\"\"", "3'"]
               csv.last << scanner.scan(@parsers[:unquoted_value_liberal_parsing])
-              unless (scanner.eos? || scanner.scan(@parsers[:col_sep]))
-                message = "Do not allow except col_sep_split_separator after quoted fields"
-                raise MalformedCSVError.new(message, lineno + 1)
-              end
+              next if scanner.eos? || scanner.scan(@parsers[:col_sep])
+              message = "Do not allow except col_sep_split_separator after quoted fields"
+              raise MalformedCSVError.new(message, lineno + 1)
             elsif scanner.eos?
               break
             else

--- a/test/csv/test_features.rb
+++ b/test/csv/test_features.rb
@@ -178,6 +178,23 @@ line,4,jkl
 
     assert_equal(["is", 'this "three', ' or four"', "fields"],
       CSV.parse_line('is,this "three, or four",fields', liberal_parsing: true))
+
+    assert_equal(["1", "\"Hamlet says, \\\"Seems", "\\\" madam! Nay it is; I know not \\\"seems.\\\"\""],
+      CSV.parse_line('1,"Hamlet says, \"Seems,\" madam! Nay it is; I know not \"seems.\""', liberal_parsing: true))
+
+    assert_equal(["one", "two\"", "three", "four"],
+      CSV.parse_line('one,two",three,four', liberal_parsing: true))
+
+    input = <<~'CSV'
+      Los Angeles,   34°03'N,    118°15'W
+      New York City, 40°42'46"N, 74°00'21"W
+      Paris,         48°51'24"N, 2°21'03"E
+    CSV
+    assert_equal(
+      [["Los Angeles", "   34°03'N", "    118°15'W"],
+       ["New York City", " 40°42'46\"N", " 74°00'21\"W"],
+       ["Paris", "         48°51'24\"N", " 2°21'03\"E"]],
+      CSV.parse(input, liberal_parsing: true))
   end
 
   def test_csv_behavior_readers


### PR DESCRIPTION
This change is intended to make it more extensible than existing parser.
It is aimed at ease of addition of options and improvement of maintainability of code.

Benchmark

```
# before change

Warming up --------------------------------------
            unquoted     5.000  i/100ms
              quoted     2.000  i/100ms
     include col_sep     1.000  i/100ms
     include row_sep     1.000  i/100ms
        encode utf-8     4.000  i/100ms
         encode sjis     4.000  i/100ms
Calculating -------------------------------------
            unquoted     59.692  (± 3.4%) i/s -    300.000  in   5.029315s
              quoted     27.762  (± 3.6%) i/s -    140.000  in   5.049609s
     include col_sep     15.317  (± 6.5%) i/s -     77.000  in   5.039037s
     include row_sep      6.526  (±15.3%) i/s -     33.000  in   5.130936s
        encode utf-8     46.373  (± 6.5%) i/s -    232.000  in   5.039316s
         encode sjis     46.922  (± 4.3%) i/s -    236.000  in   5.038045s
ruby benchmark/parse.rb  42.17s user 0.25s system 99% cpu 42.795 total

# after change

Warming up --------------------------------------
            unquoted     4.000  i/100ms
              quoted     1.000  i/100ms
     include col_sep     1.000  i/100ms
     include row_sep     1.000  i/100ms
        encode utf-8     3.000  i/100ms
         encode sjis     3.000  i/100ms
Calculating -------------------------------------
            unquoted     45.147  (± 4.4%) i/s -    228.000  in   5.057924s
              quoted     18.500  (± 5.4%) i/s -     93.000  in   5.033393s
     include col_sep     18.845  (± 5.3%) i/s -     95.000  in   5.045361s
     include row_sep      7.360  (± 0.0%) i/s -     37.000  in   5.032146s
        encode utf-8     37.648  (± 5.3%) i/s -    189.000  in   5.029352s
         encode sjis     35.967  (± 2.8%) i/s -    180.000  in   5.011789s
```