### PR TITLE
Fix string encoding of CSV.generate returns

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -534,7 +534,7 @@ class CSV
       str.seek(0, IO::SEEK_END)
     else
       encoding = options[:encoding]
-      str      = String.new
+      str      = +""
       str.force_encoding(encoding) if encoding
     end
     csv = new(str, options) # wrap

--- a/test/csv/test_interface.rb
+++ b/test/csv/test_interface.rb
@@ -211,15 +211,17 @@ class TestCSV::Interface < TestCSV
       assert_instance_of(CSV, csv)
       assert_equal(csv, csv << [1, 2, 3])
       assert_equal(csv, csv << [4, nil, 5])
+      assert_equal(csv, csv << ["あ", "い", "う"])
     end
     assert_not_nil(str)
     assert_instance_of(String, str)
-    assert_equal("1,2,3\n4,,5\n", str)
+    assert_equal("1,2,3\n4,,5\nあ,い,う\n", str)
+    assert_equal(Encoding::UTF_8, str.encoding)
 
     CSV.generate(str) do |csv|   # appending to a String
       assert_equal(csv, csv << ["last", %Q{"row"}])
     end
-    assert_equal(%Q{1,2,3\n4,,5\nlast,"""row"""\n}, str)
+    assert_equal(%Q{1,2,3\n4,,5\nあ,い,う\nlast,"""row"""\n}, str)
 
     out = CSV.generate("test") { |csv| csv << ["row"] }
     assert_equal("testrow\n", out)


### PR DESCRIPTION
Fix https://github.com/ruby/csv/issues/62

This PR will change default string encoding to UTF-8 in `CSV.generate()`.