### PR TITLE
Fix parse case of empty string with headers true

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1179,7 +1179,7 @@ class CSV
   def read
     rows = to_a
     headers = parser.headers
-    if headers || rows.empty?
+    if headers || parser.use_headers
       Table.new(rows, headers: headers)
     else
       rows

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1179,7 +1179,7 @@ class CSV
   def read
     rows = to_a
     headers = parser.headers
-    if headers
+    if headers || rows.empty?
       Table.new(rows, headers: headers)
     else
       rows

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1178,9 +1178,8 @@ class CSV
   #
   def read
     rows = to_a
-    headers = parser.headers
-    if headers || parser.use_headers
-      Table.new(rows, headers: headers)
+    if parser.use_headers?
+      Table.new(rows, headers: parser.headers)
     else
       rows
     end

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -289,7 +289,7 @@ class CSV
       end
     end
 
-    def use_headers
+    def use_headers?
       @use_headers
     end
 

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -289,6 +289,10 @@ class CSV
       end
     end
 
+    def use_headers
+      @use_headers
+    end
+
     private
     def prepare
       prepare_variable

--- a/test/csv/test_headers.rb
+++ b/test/csv/test_headers.rb
@@ -315,4 +315,9 @@ A
     assert_equal([["A"], [nil]],
                  [row.headers, row.fields])
   end
+
+  def test_empty_string_value_with_headers_true
+    row = CSV.parse('', headers: true)
+    assert_equal([], row.headers)
+  end
 end

--- a/test/csv/test_headers.rb
+++ b/test/csv/test_headers.rb
@@ -317,7 +317,7 @@ A
   end
 
   def test_empty_string_value_with_headers_true
-    row = CSV.parse('', headers: true)
-    assert_equal([], row.headers)
+    table = CSV.parse('', headers: true)
+    assert_equal(CSV::Table.new([], {}), table)
   end
 end


### PR DESCRIPTION
Fix #64

In this case "undefined method `headers' for []:Array (NoMethodError)"
was occurring.

```
row = CSV.parse('', headers: true)
p row
p row.headers
```

when CSV.parse with (headers: true) option,
return CSV::Table class is expected, but it was returned Array as below.

```
def read
  rows = to_a #=> []
  headers = parser.headers #=> nil
  if headers
    Table.new(rows, headers: headers)
  else
    rows
  end
end
```