### PR TITLE
`CSV::Row#include?` aliased twice

### DIFF
--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -123,6 +123,15 @@ class CSV
       end
     end
 
+    # Returns +true+ if there is a field with the given +header+.
+    def has_key?(header)
+      !!@row.assoc(header)
+    end
+    alias_method :include?, :has_key?
+    alias_method :key?,     :has_key?
+    alias_method :member?,  :has_key?
+    alias_method :header?,  :has_key?
+
     #
     # :call-seq:
     #   []=( header, value )
@@ -277,15 +286,6 @@ class CSV
       # return the index at the right offset, if we found one
       index.nil? ? nil : index + minimum_index
     end
-
-    # Returns +true+ if +name+ is a header for this row, and +false+ otherwise.
-    def header?(name)
-      headers.include? name
-    end
-    alias_method :key?,      :header?
-    alias_method :has_key?,  :header?
-    alias_method :member?,   :header?
-    alias_method :include?,  :header?
 
     #
     # Returns +true+ if +data+ matches a field in this row, and +false+

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -123,14 +123,6 @@ class CSV
       end
     end
 
-    # Returns +true+ if there is a field with the given +header+.
-    def has_key?(header)
-      !!@row.assoc(header)
-    end
-    alias_method :include?, :has_key?
-    alias_method :key?,     :has_key?
-    alias_method :member?,  :has_key?
-
     #
     # :call-seq:
     #   []=( header, value )
@@ -290,7 +282,10 @@ class CSV
     def header?(name)
       headers.include? name
     end
-    alias_method :include?, :header?
+    alias_method :key?,      :header?
+    alias_method :has_key?,  :header?
+    alias_method :member?,   :header?
+    alias_method :include?,  :header?
 
     #
     # Returns +true+ if +data+ matches a field in this row, and +false+

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -97,11 +97,6 @@ class TestCSVRow < Test::Unit::TestCase
     end
   end
 
-  def test_has_key?
-    assert_equal(true, @row.has_key?('B'))
-    assert_equal(false, @row.has_key?('foo'))
-  end
-
   def test_set_field
     # set field by name
     assert_equal(100, @row["A"] = 100)
@@ -261,6 +256,9 @@ class TestCSVRow < Test::Unit::TestCase
     assert_send([@row, :header?, "C"])
     assert_not_send([@row, :header?, "Z"])
     assert_send([@row, :include?, "A"])  # alias
+    assert_send([@row, :member?, "A"])  # alias
+    assert_send([@row, :key?, "A"])  # alias
+    assert_send([@row, :has_key?, "A"])  # alias
 
     # fields
     assert(@row.field?(4))

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -97,6 +97,24 @@ class TestCSVRow < Test::Unit::TestCase
     end
   end
 
+  def test_has_key?
+    assert_equal(true, @row.has_key?('B'))
+    assert_equal(false, @row.has_key?('foo'))
+
+    # aliases
+    assert_equal(true, @row.header?('B'))
+    assert_equal(false, @row.header?('foo'))
+
+    assert_equal(true, @row.include?('B'))
+    assert_equal(false, @row.include?('foo'))
+
+    assert_equal(true, @row.member?('B'))
+    assert_equal(false, @row.member?('foo'))
+
+    assert_equal(true, @row.key?('B'))
+    assert_equal(false, @row.key?('foo'))
+  end
+
   def test_set_field
     # set field by name
     assert_equal(100, @row["A"] = 100)
@@ -251,15 +269,6 @@ class TestCSVRow < Test::Unit::TestCase
   end
 
   def test_queries
-    # headers
-    assert_send([@row, :header?, "A"])
-    assert_send([@row, :header?, "C"])
-    assert_not_send([@row, :header?, "Z"])
-    assert_send([@row, :include?, "A"])  # alias
-    assert_send([@row, :member?, "A"])  # alias
-    assert_send([@row, :key?, "A"])  # alias
-    assert_send([@row, :has_key?, "A"])  # alias
-
     # fields
     assert(@row.field?(4))
     assert(@row.field?(nil))


### PR DESCRIPTION
In working on #68 I noticed `include?` is aliased twice on `CSV::Row` (with the latter alias taking precedence due to order). 

The existing `header?` method looked simplest so I got rid of `has_key?` and aliased them all to `header?`.

Feels like having duplicate aliases defined is destined to create a bug later so figured I'd fix it.
