### PR TITLE
[CHORE] Duplicate definition of _header

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1244,7 +1244,6 @@ class CSV
       end
     end
     _headers = headers
-    _headers = headers
     str << " headers:" << _headers.inspect if _headers
     str << ">"
     begin


### PR DESCRIPTION
I'm unsure what this code was originally trying to work around but I think this change makes more sense and is functionally the same.

Perhaps at some point calculating `headers` was expensive?