### PR TITLE
Add ability to convert a row on writing

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1349,7 +1349,7 @@ class CSV
   end
 
   def build_writer_fields_converter
-    generate_fields_converter(@initial_write_converters, {})
+    generate_fields_converter(@initial_write_converters, @base_fields_converter_options)
   end
 
   def generate_fields_converter(initial_converters, options)

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1328,7 +1328,7 @@ class CSV
       builtin_converters: Converters,
     }
     options = @base_fields_converter_options.merge(specific_options)
-    build_converters(@initial_converters, options)
+    generate_fields_converter(@initial_converters, options)
   end
 
   def header_fields_converter
@@ -1341,7 +1341,7 @@ class CSV
       accept_nil: true,
     }
     options = @base_fields_converter_options.merge(specific_options)
-    build_converters(@initial_header_converters, options)
+    generate_fields_converter(@initial_header_converters, options)
   end
 
   def writer_fields_converter
@@ -1349,14 +1349,10 @@ class CSV
   end
 
   def build_writer_fields_converter
-    specific_options = {
-      builtin_converters: Converters,
-    }
-    options = @base_fields_converter_options.merge(specific_options)
-    build_converters(@initial_write_converters, options)
+    generate_fields_converter(@initial_write_converters, {})
   end
 
-  def build_converters(initial_converters, options)
+  def generate_fields_converter(initial_converters, options)
     fields_converter = FieldsConverter.new(options)
     normalize_converters(initial_converters).each do |name, converter|
       fields_converter.add_converter(name, &converter)

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -954,7 +954,7 @@ class CSV
       row_separator: row_sep,
       quote_character: quote_char,
       quote_empty: quote_empty,
-      write_converters: write_converters,
+      converters: write_converters,
     }
 
     @writer = nil
@@ -1328,7 +1328,7 @@ class CSV
       builtin_converters: Converters,
     }
     options = @base_fields_converter_options.merge(specific_options)
-    parse_converters(@initial_converters, options)
+    build_converters(@initial_converters, options)
   end
 
   def header_fields_converter
@@ -1341,7 +1341,7 @@ class CSV
       accept_nil: true,
     }
     options = @base_fields_converter_options.merge(specific_options)
-    parse_converters(@initial_header_converters, options)
+    build_converters(@initial_header_converters, options)
   end
 
   def writer_fields_converter
@@ -1350,14 +1350,13 @@ class CSV
 
   def build_writer_fields_converter
     specific_options = {
-      builtin_converters: Converters
+      builtin_converters: Converters,
     }
     options = @base_fields_converter_options.merge(specific_options)
-
-    parse_converters(@initial_write_converters, options)
+    build_converters(@initial_write_converters, options)
   end
 
-  def parse_converters(initial_converters, options)
+  def build_converters(initial_converters, options)
     fields_converter = FieldsConverter.new(options)
     normalize_converters(initial_converters).each do |name, converter|
       fields_converter.add_converter(name, &converter)
@@ -1380,7 +1379,7 @@ class CSV
 
   def writer_options
     @writer_options.merge(header_fields_converter: header_fields_converter,
-                          writer_fields_converters: writer_fields_converter)
+                          fields_converter: writer_fields_converter)
   end
 end
 

--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -18,7 +18,7 @@ class CSV
       if @options[:write_headers] and @headers
         self << @headers
       end
-      @converters = @options[:fields_converter]
+      @converters = @options[:fields_converter] unless @options[:fields_converter].empty?
     end
 
     def <<(row)
@@ -32,7 +32,7 @@ class CSV
       @headers ||= row if @use_headers
       @lineno += 1
 
-      row = apply_converters_to(row, lineno) if @converters
+      row = @converters.convert(row, nil, lineno) if @converters
 
       converted_row = row.collect do |field|
         quote(field)

--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -18,6 +18,7 @@ class CSV
       if @options[:write_headers] and @headers
         self << @headers
       end
+      @converters = @options[:fields_converter]
     end
 
     def <<(row)
@@ -31,7 +32,7 @@ class CSV
       @headers ||= row if @use_headers
       @lineno += 1
 
-      apply_converters_to(row, lineno)
+      row = apply_converters_to(row, lineno) if @converters
 
       converted_row = row.collect do |field|
         quote(field)
@@ -153,8 +154,7 @@ class CSV
     end
 
     def apply_converters_to(row, lineno)
-      converter = @options[:writer_fields_converters]
-      converter.convert(row, nil, lineno) if converter
+      @converters.convert(row, nil, lineno)
     end
   end
 end

--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -18,7 +18,7 @@ class CSV
       if @options[:write_headers] and @headers
         self << @headers
       end
-      @converters = @options[:fields_converter]
+      @fields_converter = @options[:fields_converter]
     end
 
     def <<(row)
@@ -32,7 +32,7 @@ class CSV
       @headers ||= row if @use_headers
       @lineno += 1
 
-      row = @converters.convert(row, nil, lineno) if @converters
+      row = @fields_converter.convert(row, nil, lineno) if @fields_converter
 
       converted_row = row.collect do |field|
         quote(field)

--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -31,6 +31,8 @@ class CSV
       @headers ||= row if @use_headers
       @lineno += 1
 
+      apply_converters_to(row, lineno)
+
       converted_row = row.collect do |field|
         quote(field)
       end
@@ -148,6 +150,11 @@ class CSV
           end
         end
       end
+    end
+
+    def apply_converters_to(row, lineno)
+      converter = @options[:writer_fields_converters]
+      converter.convert(row, nil, lineno) if converter
     end
   end
 end

--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -152,9 +152,5 @@ class CSV
         end
       end
     end
-
-    def apply_converters_to(row, lineno)
-      @converters.convert(row, nil, lineno)
-    end
   end
 end

--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -18,7 +18,7 @@ class CSV
       if @options[:write_headers] and @headers
         self << @headers
       end
-      @converters = @options[:fields_converter] unless @options[:fields_converter].empty?
+      @converters = @options[:fields_converter]
     end
 
     def <<(row)

--- a/test/csv/write/test_general.rb
+++ b/test/csv/write/test_general.rb
@@ -209,7 +209,7 @@ module TestCSVWriteGeneral
   def test_write_converters
     assert_equal(%Q[=a,=b,=c\n],
                  generate_line(["a", "b", "c"],
-                               write_converters: ->(value) { value.prepend('=') } ))
+                               write_converters: ->(value) { '=' + value } ))
   end
 end
 

--- a/test/csv/write/test_general.rb
+++ b/test/csv/write/test_general.rb
@@ -205,6 +205,12 @@ module TestCSVWriteGeneral
     assert_equal(%Q[あ,い,う#{$INPUT_RECORD_SEPARATOR}].encode("EUC-JP"),
                  generate_line(row))
   end
+
+  def test_write_converters
+    assert_equal(%Q[=a,=b,=c\n],
+                 generate_line(["a", "b", "c"],
+                               write_converters: ->(value) { value.prepend('=') } ))
+  end
 end
 
 class TestCSVWriteGeneralGenerateLine < Test::Unit::TestCase


### PR DESCRIPTION
Just adding the ability to use `write_converters` when creating CSV data. It is supposed to fix #46. I am allowing the builtins converters to be used, but I'm not sure if you guys want to keep this behaviour.

Another thing I'm not entirely sure is what else I can test, so it would be nice if someone can suggest more sensitive points in the code that can be covered.