### PR TITLE
Support backslash_quote #61

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ namespace :benchmark do
     benchmark_tasks << "benchmark:#{name}"
 
     case name
-    when "parse", "shift"
+    when "parse", "shift", "parse_liberal_parsing"
       namespace name do
         desc "Run #{name} benchmark: small"
         task :small do

--- a/benchmark/parse_liberal_parsing.yaml
+++ b/benchmark/parse_liberal_parsing.yaml
@@ -19,13 +19,8 @@ prelude: |-
 benchmark:
   unquoted: |-
     CSV.parse(unquoted, liberal_parsing: true)
-  unquoted_double_quote_outside_quote: |-
-    CSV.parse(unquoted, liberal_parsing: {
-                          double_quote_outside_quote: true
-                        })
   unquoted_backslash_quote: |-
     CSV.parse(unquoted, liberal_parsing: {
-                          double_quote_outside_quote: true,
                           backslash_quote: true,
                         })
   quoted: |-

--- a/benchmark/parse_liberal_parsing.yaml
+++ b/benchmark/parse_liberal_parsing.yaml
@@ -1,0 +1,49 @@
+contexts:
+  - gems:
+      csv: 3.0.2
+  - name: "master"
+    prelude: |
+      $LOAD_PATH.unshift(File.expand_path("lib"))
+      require "csv"
+prelude: |-
+  n_columns = Integer(ENV.fetch("N_COLUMNS", "50"), 10)
+  n_rows = Integer(ENV.fetch("N_ROWS", "1000"), 10)
+  alphas = ['\"\"a\"\"'] * n_columns
+  unquoted = (alphas.join(",") + "\r\n") * n_rows
+  quoted = (alphas.map { |s| %("#{s}") }.join(",") + "\r\n") * n_rows
+  inc_col_sep = (alphas.map { |s| %(",#{s}") }.join(",") + "\r\n") * n_rows
+  inc_row_sep = (alphas.map { |s| %("#{s}") }.join(",") + "\r\n") * n_rows
+  hiraganas = ["あああああ"] * n_columns
+  enc_utf8 = (hiraganas.join(",") + "\r\n") * n_rows
+  enc_sjis = enc_utf8.encode("Windows-31J")
+benchmark:
+  unquoted: |-
+    CSV.parse(unquoted, liberal_parsing: true)
+  unquoted_double_quote_outside_quote: |-
+    CSV.parse(unquoted, liberal_parsing: {
+                          double_quote_outside_quote: true
+                        })
+  unquoted_backslash_quote: |-
+    CSV.parse(unquoted, liberal_parsing: {
+                          double_quote_outside_quote: true,
+                          backslash_quote: true,
+                        })
+  quoted: |-
+    CSV.parse(quoted, liberal_parsing: true)
+  quoted_double_quote_outside_quote: |-
+    CSV.parse(quoted, liberal_parsing: {
+                        double_quote_outside_quote: true
+                      })
+  quoted_backslash_quote: |-
+    CSV.parse(quoted, liberal_parsing: {
+                        double_quote_outside_quote: true,
+                        backslash_quote: true,
+                      })
+  include_col_sep: |-
+    CSV.parse(inc_col_sep, liberal_parsing: true)
+  include_row_sep: |-
+    CSV.parse(inc_row_sep, liberal_parsing: true)
+  encode_utf-8: |-
+    CSV.parse(enc_utf8, liberal_parsing: true)
+  encode_sjis: |-
+    CSV.parse(enc_sjis, liberal_parsing: true)

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -669,9 +669,6 @@ class CSV
 
     def parse_unquoted_column_value
       value = @scanner.scan_all(@unquoted_value)
-      if @backslash_quote and value
-        value = value.gsub(@escaped_backslash_quote_character, @quote_character)
-      end
       return nil unless value
 
       @unquoted_column_value = true
@@ -691,6 +688,7 @@ class CSV
           value << sub_value
         end
       end
+      value.gsub!(@backslash_quote_character, @quote_character) if @backslash_quote
       value
     end
 

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -661,6 +661,9 @@ class CSV
 
     def parse_unquoted_column_value
       value = @scanner.scan_all(@unquoted_value)
+      if @backslash_quote and value
+        value = value.gsub(@escaped_quote_character, @quote_character)
+      end
       return nil unless value
 
       @unquoted_column_value = true

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -653,7 +653,7 @@ class CSV
           break unless backslash
           quote = @scanner.scan(@escaped_quote)
           if quote
-            value << backslash << quote 
+            value << quote
           else
             # If it is not quote_character after backslash, which is not closed by quote.
             message = "Unclosed quoted field"

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -343,7 +343,7 @@ class CSV
       escaped_first_column_separator = Regexp.escape(@column_separator[0])
       escaped_row_separator = Regexp.escape(@row_separator)
       escaped_quote_character = Regexp.escape(@quote_character)
-      escaped_escape_character = Regexp.escape("\\".encode(@encoding))
+      escaped_backslash_character = Regexp.escape("\\".encode(@encoding))
       @escaped_quote_character = "\\".encode(@encoding) + escaped_quote_character
 
       skip_lines = @options[:skip_lines]
@@ -381,7 +381,7 @@ class CSV
         @row_ends = nil
       end
       @escaped_quotes = Regexp.new("(".encode(@encoding) +
-                           escaped_escape_character +
+                           escaped_backslash_character +
                            escaped_quote_character +
                            ")".encode(@encoding) +
                            "+".encode(@encoding))
@@ -390,7 +390,7 @@ class CSV
       if @backslash_quote
         @quoted_value = Regexp.new("[^".encode(@encoding) +
                                    escaped_quote_character +
-                                   escaped_escape_character +
+                                   escaped_backslash_character +
                                    "]+".encode(@encoding))
       else
         @quoted_value = Regexp.new("[^".encode(@encoding) +

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -100,8 +100,15 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
                  ],
                  [
                    CSV.parse(data, liberal_parsing: true),
-                   CSV.parse(data, liberal_parsing: { backslash_quote: true }),
-                   CSV.parse(data, liberal_parsing: { backslash_quote: true, double_quote_outside_quote: true }),
+                   CSV.parse(data,
+                             liberal_parsing: {
+                               backslash_quote: true
+                             }),
+                   CSV.parse(data,
+                             liberal_parsing: {
+                               backslash_quote: true,
+                               double_quote_outside_quote: true
+                             }),
                  ])
   end
 
@@ -114,8 +121,15 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
                  ],
                  [
                    CSV.parse(data, liberal_parsing: true),
-                   CSV.parse(data, liberal_parsing: { backslash_quote: true }),
-                   CSV.parse(data, liberal_parsing: { backslash_quote: true, double_quote_outside_quote: true }),
+                   CSV.parse(data,
+                             liberal_parsing: {
+                               backslash_quote: true
+                             }),
+                   CSV.parse(data,
+                             liberal_parsing: {
+                               backslash_quote: true,
+                               double_quote_outside_quote: true
+                             }),
                  ])
   end
 
@@ -128,8 +142,15 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
                  ],
                  [
                    CSV.parse(data, liberal_parsing: true),
-                   CSV.parse(data, liberal_parsing: { backslash_quote: true }),
-                   CSV.parse(data, liberal_parsing: { backslash_quote: true, double_quote_outside_quote: true }),
+                   CSV.parse(data,
+                             liberal_parsing: {
+                               backslash_quote: true
+                             }),
+                   CSV.parse(data,
+                             liberal_parsing: {
+                               backslash_quote: true,
+                               double_quote_outside_quote: true
+                             }),
                  ])
   end
 end

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -90,4 +90,32 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
                              }),
                  ])
   end
+
+  def test_backslash_quote_double_quote_outside_quote
+    data = %Q{a,""b""}
+    assert_equal([
+                   [["a", "\"\"b\"\""]],
+                   [["a", "\"\"b\"\""]],
+                   [["a", "\"b\""]],
+                 ],
+                 [
+                   CSV.parse(data, liberal_parsing: true),
+                   CSV.parse(data, liberal_parsing: { backslash_quote: true }),
+                   CSV.parse(data, liberal_parsing: { backslash_quote: true, double_quote_outside_quote: true }),
+                 ])
+  end
+
+  def test_backslash_quote_true_with_quoted_value
+    data = '"\"\"a\"\""'
+    assert_equal([
+                   [["\"\\\"\\\"a\\\"\\\"\""]],
+                   [["\"\"a\"\""]],
+                   [["\"\"a\"\""]],
+                 ],
+                 [
+                   CSV.parse(data, liberal_parsing: true),
+                   CSV.parse(data, liberal_parsing: { backslash_quote: true }),
+                   CSV.parse(data, liberal_parsing: { backslash_quote: true, double_quote_outside_quote: true }),
+                 ])
+  end
 end

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -91,66 +91,62 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
                  ])
   end
 
-  def test_backslash_quote_double_quote_outside_quote
-    data = %Q{a,""b""}
-    assert_equal([
-                   [["a", "\"\"b\"\""]],
-                   [["a", "\"\"b\"\""]],
-                   [["a", "\"b\""]],
-                 ],
-                 [
-                   CSV.parse(data, liberal_parsing: true),
-                   CSV.parse(data,
-                             liberal_parsing: {
-                               backslash_quote: true
-                             }),
-                   CSV.parse(data,
-                             liberal_parsing: {
-                               backslash_quote: true,
-                               double_quote_outside_quote: true
-                             }),
-                 ])
-  end
+  class TestBackslashQuote < Test::Unit::TestCase
+    def test_double_quote_outside_quote
+      data = %Q{a,""b""}
+      assert_equal([
+                     [["a", %Q{""b""}]],
+                     [["a", %Q{""b""}]],
+                     [["a", %Q{"b"}]],
+                   ],
+                   [
+                     CSV.parse(data, liberal_parsing: true),
+                     CSV.parse(data,
+                               liberal_parsing: {
+                                 backslash_quote: true
+                               }),
+                     CSV.parse(data,
+                               liberal_parsing: {
+                                 backslash_quote: true,
+                                 double_quote_outside_quote: true
+                               }),
+                   ])
+    end
 
-  def test_backslash_quote_true_with_unquoted_value
-    data = '\"\"a\"\"'
-    assert_equal([
-                   [["\\\"\\\"a\\\"\\\""]],
-                   [["\"\"a\"\""]],
-                   [["\"\"a\"\""]]
-                 ],
-                 [
-                   CSV.parse(data, liberal_parsing: true),
-                   CSV.parse(data,
-                             liberal_parsing: {
-                               backslash_quote: true
-                             }),
-                   CSV.parse(data,
-                             liberal_parsing: {
-                               backslash_quote: true,
-                               double_quote_outside_quote: true
-                             }),
-                 ])
-  end
+    def test_unquoted_value
+      data = '\"\"a\"\"'
+      assert_equal([
+                     [[%Q{\\\"\\\"a\\\"\\\"}]],
+                     [[%Q{\"\"a\"\"}]],
+                   ],
+                   [
+                     CSV.parse(data, liberal_parsing: true),
+                     CSV.parse(data,
+                               liberal_parsing: {
+                                 backslash_quote: true
+                               }),
+                   ])
+    end
 
-  def test_backslash_quote_true_with_quoted_value
-    data = '"\"\"a\"\""'
-    assert_equal([
-                   [["\"\\\"\\\"a\\\"\\\"\""]],
-                   [["\"\"a\"\""]],
-                   [["\"\"a\"\""]],
-                 ],
-                 [
-                   CSV.parse(data, liberal_parsing: true),
-                   CSV.parse(data,
-                             liberal_parsing: {
-                               backslash_quote: true
-                             }),
-                   CSV.parse(data,
-                             liberal_parsing: {
-                               backslash_quote: true,
-                               double_quote_outside_quote: true
-                             }),
-                 ])
+    def test_quoted_value
+      data = '"\"\"a\"\""'
+      assert_equal([
+                     [[%Q{\"\\\"\\\"a\\\"\\\"\"}]],
+                     [[%Q{\"\"a\"\"}]],
+                     [[%Q{\"\"a\"\"}]],
+                   ],
+                   [
+                     CSV.parse(data, liberal_parsing: true),
+                     CSV.parse(data,
+                               liberal_parsing: {
+                                 backslash_quote: true
+                               }),
+                     CSV.parse(data,
+                               liberal_parsing: {
+                                 backslash_quote: true,
+                                 double_quote_outside_quote: true
+                               }),
+                   ])
+    end
   end
 end

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -105,6 +105,20 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
                  ])
   end
 
+  def test_backslash_quote_true_with_unquoted_value
+    data = '\"\"a\"\"'
+    assert_equal([
+                   [["\\\"\\\"a\\\"\\\""]],
+                   [["\"\"a\"\""]],
+                   [["\"\"a\"\""]]
+                 ],
+                 [
+                   CSV.parse(data, liberal_parsing: true),
+                   CSV.parse(data, liberal_parsing: { backslash_quote: true }),
+                   CSV.parse(data, liberal_parsing: { backslash_quote: true, double_quote_outside_quote: true }),
+                 ])
+  end
+
   def test_backslash_quote_true_with_quoted_value
     data = '"\"\"a\"\""'
     assert_equal([

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -128,6 +128,27 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
                    ])
     end
 
+    def test_unquoted_value_multiple_characters_col_sep
+      data = 'a<\\"b<=>x'
+      assert_equal([
+                     [[%Q{a<\\\"b<=>x}]],
+                     [[%Q{a<"b<=>x}]],
+                     [[%Q{a<"b}, "x"]],
+                   ],
+                   [
+                     CSV.parse(data, liberal_parsing: true),
+                     CSV.parse(data,
+                               liberal_parsing: {
+                                 backslash_quote: true
+                               }),
+                     CSV.parse(data,
+                               col_sep: "<=>",
+                               liberal_parsing: {
+                                 backslash_quote: true
+                               }),
+                   ])
+    end
+
     def test_quoted_value
       data = '"\"\"a\"\""'
       assert_equal([


### PR DESCRIPTION
I Implemented `backslash_quote` option as below. #61

```ruby
data = '"\"\"a\"\""'
CSV.parse(data, liberal_parsing: { backslash_quote: true })
#=> ""a""
```