### PR TITLE
Fix CSV#shift regression (introduced in 3.0.2)

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1173,7 +1173,7 @@ class CSV
     return to_enum(__method__) unless block_given?
     @parser_enumerator ||= parser.parse
     begin
-      loop do
+      while true
         yield @parser_enumerator.next
       end
     rescue StopIteration
@@ -1210,8 +1210,9 @@ class CSV
   # The data source must be open for reading.
   #
   def shift
+    @parser_enumerator ||= parser.parse
     begin
-      each.next
+      @parser_enumerator.next
     rescue StopIteration
       nil
     end

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1169,8 +1169,16 @@ class CSV
   #
   # The data source must be open for reading.
   #
-  def each(&block)
-    parser.parse(&block)
+  def each
+    return to_enum(__method__) unless block_given?
+    @parser_enumerator ||= parser.parse
+    begin
+      loop do
+        yield @parser_enumerator.next
+      end
+    rescue StopIteration
+    end
+    self
   end
 
   #
@@ -1202,9 +1210,8 @@ class CSV
   # The data source must be open for reading.
   #
   def shift
-    @parser_enumerator ||= parser.parse
     begin
-      @parser_enumerator.next
+      each.next
     rescue StopIteration
       nil
     end

--- a/test/csv/test_interface.rb
+++ b/test/csv/test_interface.rb
@@ -190,6 +190,20 @@ class TestCSV::Interface < TestCSV
     end
   end
 
+  def test_shift_removes_from_each
+    CSV.open(@path, col_sep: "\t", row_sep: "\r\n") do |csv|
+      assert_equal(@expected.shift, csv.shift)
+      assert_equal(@expected.count, csv.count)
+    end
+  end
+
+  def test_each_consumes
+    CSV.open(@path, col_sep: "\t", row_sep: "\r\n") do |csv|
+      csv.each do end
+      assert_equal(0, csv.count)
+    end
+  end
+
   def test_nil_is_not_acceptable
     assert_raise_with_message ArgumentError, "Cannot parse nil as CSV" do
       CSV.new(nil)


### PR DESCRIPTION
Prior to 39da059c6d363136a80867a6cdb7f2ac42e48ecc, shifting a value from a `CSV`, and then using an `Enumerable` method, would not include the shifted value in the result of the `Enumerable` method.

This behavior made sense. The `#shift` methods on `Array` and `Hash` both behave this same way, because they both remove an element from the underlying data structure. It makes sense for `CSV#shift` to work like this to, as it used to.

To fix this regression, there needs to be an internal position that is advanced when calling `#shift`, which `#each` will then start from. By re-implementing `#each` in terms of `Enumerator#next`, we get this for free. This also allows `#shift` to be re-implemented in terms of `#each`.

It might seem that this would break using `#each` multiple times without sending `#rewind` in between, but it turns out this has never been supported anyway. I've added a test for this behaviour so as to document it.