### PR TITLE
Fix line number in invalid byte sequence error

### DIFF
--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -575,9 +575,9 @@ class CSV
           string = @samples[0]
         end
         if string
-          unless string.valid_encoding?
+          if index = string.lines(@row_separator).index { |l| !l.valid_encoding? }
             message = "Invalid byte sequence in #{@encoding}"
-            raise MalformedCSVError.new(message, @lineno + 1)
+            raise MalformedCSVError.new(message, @lineno + index + 1)
           end
           Scanner.new(string)
         else

--- a/test/csv/test_encodings.rb
+++ b/test/csv/test_encodings.rb
@@ -256,12 +256,13 @@ class TestCSVEncodings < Test::Unit::TestCase
   end
 
   def test_invalid_encoding_row_error
-    csv = CSV.new("invalid,\xF8\r\nvalid,x\r\n".force_encoding("UTF-8"),
-                  encoding: "UTF-8")
+    csv = CSV.new("valid,x\rinvalid,\xF8\r".force_encoding("UTF-8"),
+                  encoding: "UTF-8", row_sep: "\r")
     error = assert_raise(CSV::MalformedCSVError) do
       csv.shift
+      csv.shift
     end
-    assert_equal("Invalid byte sequence in UTF-8 in line 1.",
+    assert_equal("Invalid byte sequence in UTF-8 in line 2.",
                  error.message)
   end
 


### PR DESCRIPTION
This didn't take into account that the sample could be composed of multiple lines, and so the index of the malformed line in the sample wasn't taken into account when calculating the line number.

I chose to just change the existing test for this to have the error on line two, rather than writing a whole new test, because I think it's much more likely that 1 will be returned incorrectly than 2, so this way it's just an all around better test.