### PR TITLE
Add optimization for quote_char: nil

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ namespace :benchmark do
     benchmark_tasks << "benchmark:#{name}"
 
     case name
-    when "parse", "shift", "parse_liberal_parsing"
+    when "parse", "shift", "parse_liberal_parsing", "parse_quote_char_nil"
       namespace name do
         desc "Run #{name} benchmark: small"
         task :small do

--- a/benchmark/parse_quote_char_nil.yaml
+++ b/benchmark/parse_quote_char_nil.yaml
@@ -9,9 +9,6 @@ prelude: |-
   alphas = ["AAAAA"] * n_columns
   unquoted = (alphas.join(",") + "\r\n") * n_rows
   col_sep_space = (alphas.join(" ") + "\r\n") * n_rows
-  hiraganas = ["あああああ"] * n_columns
-  enc_utf8 = (hiraganas.join(",") + "\r\n") * n_rows
-  enc_sjis = enc_utf8.encode("Windows-31J")
 
 benchmark:
   without_quote_char: |-
@@ -20,7 +17,3 @@ benchmark:
     CSV.parse(unquoted, quote_char: nil)
   col_sep_space: |-
     CSV.parse(col_sep_space, quote_char: nil, col_sep: " ")
-  encode_utf-8: |-
-    CSV.parse(enc_utf8, quote_char: nil)
-  encode_sjis: |-
-    CSV.parse(enc_sjis, quote_char: nil)

--- a/benchmark/parse_quote_char_nil.yaml
+++ b/benchmark/parse_quote_char_nil.yaml
@@ -1,0 +1,26 @@
+contexts:
+  - name: "master"
+    prelude: |
+      $LOAD_PATH.unshift(File.expand_path("lib"))
+      require "csv"
+prelude: |-
+  n_columns = Integer(ENV.fetch("N_COLUMNS", "50"), 10)
+  n_rows = Integer(ENV.fetch("N_ROWS", "1000"), 10)
+  alphas = ["AAAAA"] * n_columns
+  unquoted = (alphas.join(",") + "\r\n") * n_rows
+  col_sep_space = (alphas.join(" ") + "\r\n") * n_rows
+  hiraganas = ["あああああ"] * n_columns
+  enc_utf8 = (hiraganas.join(",") + "\r\n") * n_rows
+  enc_sjis = enc_utf8.encode("Windows-31J")
+
+benchmark:
+  without_quote_char: |-
+    CSV.parse(unquoted)
+  quote_char_nil: |-
+    CSV.parse(unquoted, quote_char: nil)
+  col_sep_space: |-
+    CSV.parse(col_sep_space, quote_char: nil, col_sep: " ")
+  encode_utf-8: |-
+    CSV.parse(enc_utf8, quote_char: nil)
+  encode_sjis: |-
+    CSV.parse(enc_sjis, quote_char: nil)

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -347,9 +347,6 @@ class CSV
         if @quote_character.length != 1
           raise ArgumentError, ":quote_char has to be a single character String"
         end
-        escaped_quote_character = Regexp.escape(@quote_character)
-        @escaped_quote = Regexp.new(escaped_quote_character)
-        @backslash_quote_character = @backslash_character + escaped_quote_character
       end
 
       escaped_column_separator = Regexp.escape(@column_separator)
@@ -357,6 +354,11 @@ class CSV
       escaped_row_separator = Regexp.escape(@row_separator)
       escaped_backslash_character = Regexp.escape(@backslash_character)
       @escaped_backslash = Regexp.new(escaped_backslash_character)
+      if @quote_character
+        escaped_quote_character = Regexp.escape(@quote_character)
+        @escaped_quote = Regexp.new(escaped_quote_character)
+        @backslash_quote_character = @backslash_character + escaped_quote_character
+      end
 
       skip_lines = @options[:skip_lines]
       case skip_lines

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -345,7 +345,7 @@ class CSV
       else
         @quote_character = @options[:quote_character].to_s.encode(@encoding)
         if @quote_character.length != 1
-          raise ArgumentError, ":quote_char has to be a single character String"
+          raise ArgumentError, ":quote_char has to be nil or a single character String"
         end
       end
 

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -393,7 +393,7 @@ class CSV
         @row_ends = nil
       end
 
-      if @options[:quote_character]
+      if @quote_character
         @quotes = Regexp.new(escaped_quote_character +
                              "+".encode(@encoding))
         if @backslash_quote
@@ -412,7 +412,7 @@ class CSV
         @unquoted_value = Regexp.new("[^".encode(@encoding) +
                                      escaped_first_column_separator +
                                      "\r\n]+".encode(@encoding))
-      elsif @options[:quote_character]
+      elsif @quote_character
         @unquoted_value = Regexp.new("[^".encode(@encoding) +
                                      escaped_quote_character +
                                      escaped_first_column_separator +

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -753,8 +753,7 @@ class CSV
     end
 
     def parse_quote_character_nil(&block)
-      while true
-        return nil unless value = @input.gets(@row_separator)
+      @input.string.each_line(@row_separator) do |value|
         next if @skip_lines and skip_line?(value)
         value.chomp!
 

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -761,13 +761,16 @@ class CSV
         if value.empty?
           next if @skip_blanks
         else
-          columns = if @column_separator == " "
+          row = if @column_separator == " "
             value.split(@column_end, -1)
           else
             value.split(@column_separator, -1)
           end
-          columns.each do |column|
-            row << (column.empty? ? nil : column)
+          n_columns = row.size
+          i = 0
+          while i < n_columns
+            row[i] = nil if row[i].empty?
+            i += 1
           end
         end
         @last_line = value

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -306,7 +306,7 @@ class CSV
       prepare_regexp
       prepare_line
       prepare_header
-      prepare_parser if @options[:quote_character]
+      prepare_parser
     end
 
     def prepare_variable
@@ -539,7 +539,7 @@ class CSV
     end
 
     def prepare_parser
-      @may_quoted = may_quoted?
+      @may_quoted = may_quoted? if @options[:quote_character]
     end
 
     def may_quoted?

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -227,33 +227,6 @@ class CSV
       last_line
     end
 
-    def parse_quote_character_nil(&block)
-      while true
-        return nil unless value = @input.gets(@row_separator)
-        next if @skip_lines and skip_line?(value)
-
-        value.chomp!
-
-        row = []
-        if value.empty?
-          next if @skip_blanks
-        else
-          columns = if @column_separator == " "
-            value.split(@column_end, -1)
-          else
-            value.split(@column_separator, -1)
-          end
-          columns.each do |column|
-            row << (column.empty? ? nil : column)
-          end
-        end
-        @last_line = value
-
-        emit_row(row, &block)
-      end
-      @parsed = true
-    end
-
     def parse(&block)
       return to_enum(__method__) unless block_given?
 
@@ -777,6 +750,31 @@ class CSV
         @scanner.keep_back
         false
       end
+    end
+
+    def parse_quote_character_nil(&block)
+      while true
+        return nil unless value = @input.gets(@row_separator)
+        next if @skip_lines and skip_line?(value)
+        value.chomp!
+
+        row = []
+        if value.empty?
+          next if @skip_blanks
+        else
+          columns = if @column_separator == " "
+            value.split(@column_end, -1)
+          else
+            value.split(@column_separator, -1)
+          end
+          columns.each do |column|
+            row << (column.empty? ? nil : column)
+          end
+        end
+        @last_line = value
+        emit_row(row, &block)
+      end
+      @parsed = true
     end
 
     def start_row

--- a/test/csv/parse/test_quote_char_nil.rb
+++ b/test/csv/parse/test_quote_char_nil.rb
@@ -7,12 +7,15 @@ class TestCSVParseQuoteCharNil < Test::Unit::TestCase
   extend DifferentOFS
 
   def test_general
-    [[%Q{a,b},  ["a", "b"]],
-     [%Q{a,,,}, ["a", nil, nil, nil]],
-     [%Q{,},    [nil, nil]],
-    ].each do |edge_case|
-      assert_equal(edge_case.last, CSV.parse_line(edge_case.first, quote_char: nil))
-    end
+    assert_equal(["a", "b"], CSV.parse_line(%Q{a,b}, quote_char: nil))
+  end
+
+  def test_end_with_nil
+    assert_equal(["a", nil, nil, nil], CSV.parse_line(%Q{a,,,}, quote_char: nil))
+  end
+
+  def test_nil_nil
+    assert_equal([nil, nil], CSV.parse_line(%Q{,}, quote_char: nil))
   end
 
   def test_unquoted_value_multiple_characters_col_sep

--- a/test/csv/parse/test_quote_char_nil.rb
+++ b/test/csv/parse/test_quote_char_nil.rb
@@ -31,9 +31,6 @@ class TestCSVParseQuoteCharNil < Test::Unit::TestCase
       A,B,C
       1,2,3
     DATA
-    assert_nothing_raised(Exception) do
-      csv = CSV.parse(data, headers: "my,new,headers", quote_char: nil)
-    end
 
     # first data row - skipping headers
     row = csv[0]

--- a/test/csv/parse/test_quote_char_nil.rb
+++ b/test/csv/parse/test_quote_char_nil.rb
@@ -24,6 +24,11 @@ class TestCSVParseQuoteCharNil < Test::Unit::TestCase
   end
 
   def test_csv_header_string
+    data = <<~DATA
+      first,second,third
+      A,B,C
+      1,2,3
+    DATA
     assert_equal(
       CSV::Table.new([
         CSV::Row.new(["my", "new", "headers"], ["first", "second", "third"]),

--- a/test/csv/parse/test_quote_char_nil.rb
+++ b/test/csv/parse/test_quote_char_nil.rb
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: false
+
+require_relative "../helper"
+
+class TestCSVParseQuoteCharNil < Test::Unit::TestCase
+  extend DifferentOFS
+
+  def test_general
+    [[%Q{a,b},  ["a", "b"]],
+     [%Q{a,,,}, ["a", nil, nil, nil]],
+     [%Q{,},    [nil, nil]],
+    ].each do |edge_case|
+      assert_equal(edge_case.last, CSV.parse_line(edge_case.first, quote_char: nil))
+    end
+  end
+
+  def test_unquoted_value_multiple_characters_col_sep
+    data = %q{a<b<=>x}
+    assert_equal([[%Q{a<b}, "x"]], CSV.parse(data, col_sep: "<=>", quote_char: nil))
+  end
+
+  def test_csv_header_string
+    # activate headers
+    csv = nil
+    data = <<~DATA
+      first,second,third
+      A,B,C
+      1,2,3
+    DATA
+    assert_nothing_raised(Exception) do
+      csv = CSV.parse(data, headers: "my,new,headers", quote_char: nil)
+    end
+
+    # first data row - skipping headers
+    row = csv[0]
+    assert_not_nil(row)
+    assert_instance_of(CSV::Row, row)
+    assert_equal([%w{my first}, %w{new second}, %w{headers third}], row.to_a)
+
+    # second data row
+    row = csv[1]
+    assert_not_nil(row)
+    assert_instance_of(CSV::Row, row)
+    assert_equal([%w{my A}, %w{new B}, %w{headers C}], row.to_a)
+
+    # third data row
+    row = csv[2]
+    assert_not_nil(row)
+    assert_instance_of(CSV::Row, row)
+    assert_equal([%w{my 1}, %w{new 2}, %w{headers 3}], row.to_a)
+
+    # empty
+    assert_nil(csv[3])
+  end
+
+  def test_comma
+    assert_equal([["a", "b", nil, "d"]],
+                 CSV.parse("a,b,,d", col_sep: ",", quote_char: nil))
+  end
+
+  def test_space
+    assert_equal([["a", "b", nil, "d"]],
+                 CSV.parse("a b  d", col_sep: " ", quote_char: nil))
+  end
+
+  def test_multiple_space
+    assert_equal([["a b", nil, "d"]],
+                 CSV.parse("a b    d", col_sep: "  ", quote_char: nil))
+  end
+
+  def test_multiple_characters_leading_empty_fields
+    data = <<-CSV
+<=><=>A<=>B<=>C
+1<=>2<=>3
+    CSV
+    assert_equal([
+                   [nil, nil, "A", "B", "C"],
+                   ["1", "2", "3"],
+                 ],
+                 CSV.parse(data, col_sep: "<=>", quote_char: nil))
+  end
+end

--- a/test/csv/parse/test_quote_char_nil.rb
+++ b/test/csv/parse/test_quote_char_nil.rb
@@ -24,34 +24,14 @@ class TestCSVParseQuoteCharNil < Test::Unit::TestCase
   end
 
   def test_csv_header_string
-    # activate headers
-    csv = nil
-    data = <<~DATA
-      first,second,third
-      A,B,C
-      1,2,3
-    DATA
-
-    # first data row - skipping headers
-    row = csv[0]
-    assert_not_nil(row)
-    assert_instance_of(CSV::Row, row)
-    assert_equal([%w{my first}, %w{new second}, %w{headers third}], row.to_a)
-
-    # second data row
-    row = csv[1]
-    assert_not_nil(row)
-    assert_instance_of(CSV::Row, row)
-    assert_equal([%w{my A}, %w{new B}, %w{headers C}], row.to_a)
-
-    # third data row
-    row = csv[2]
-    assert_not_nil(row)
-    assert_instance_of(CSV::Row, row)
-    assert_equal([%w{my 1}, %w{new 2}, %w{headers 3}], row.to_a)
-
-    # empty
-    assert_nil(csv[3])
+    assert_equal(
+      CSV::Table.new([
+        CSV::Row.new(["my", "new", "headers"], ["first", "second", "third"]),
+        CSV::Row.new(["my", "new", "headers"], ["A", "B", "C"]),
+        CSV::Row.new(["my", "new", "headers"], ["1", "2", "3"])
+      ]),
+      CSV.parse(data, headers: "my,new,headers", quote_char: nil)
+    )
   end
 
   def test_comma


### PR DESCRIPTION
I implement https://github.com/ruby/csv/issues/56

This implementation uses `line.split(column_separator)` to parse. As a result, it got 2.7x faster for `quote_char: nil` case.
Also, as the number of columns to parse increases, `quote_char: nil` is more advantageous in terms of performance.

```
benchmark:
$ rake benchmark:parse_quote_char_nil

(Case of 50 columns)
Comparison:
      quote_char_nil:        76.4 i/s 
         encode_sjis:        52.9 i/s - 1.45x  slower
        encode_utf-8:        51.5 i/s - 1.48x  slower
       col_sep_space:        48.3 i/s - 1.58x  slower
  without_quote_char:        28.3 i/s - 2.70x  slower

(Case of 10 columns)
Comparison:
      quote_char_nil:       265.4 i/s 
         encode_sjis:       206.5 i/s - 1.29x  slower
        encode_utf-8:       196.9 i/s - 1.35x  slower
       col_sep_space:       172.6 i/s - 1.54x  slower
  without_quote_char:       120.9 i/s - 2.20x  slower
```

If col_sep is a single byte blank character `" "`, `String#split` is divided by a blank string after excluding leading and trailing blanks.
In order to support the following cases, use regular expression in `String#split` only when col_sep is a space character.

```ruby
CSV.parse("a b  d", col_sep: " ", quote_char: nil)
#=> [["a", "b", nil, "d"]]
```

However, when using regular expressions, it is about 1.5 times slower than using strings. The above col_sep_space is the benchmark result. Even in this case it is faster than the existing parse implementation.

Unfortunately, This implementation currently does not support stream.