### PR TITLE
Fix CSV delegation to missing StringIO methods

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1106,12 +1106,44 @@ class CSV
   ### IO and StringIO Delegation ###
 
   extend Forwardable
-  def_delegators :@io, :binmode, :binmode?, :close, :close_read, :close_write,
+  def_delegators :@io, :binmode, :close, :close_read, :close_write,
                        :closed?, :external_encoding, :fcntl,
-                       :fileno, :flock, :flush, :fsync, :internal_encoding,
-                       :ioctl, :isatty, :path, :pid, :pos, :pos=, :reopen,
-                       :seek, :stat, :string, :sync, :sync=, :tell, :to_i,
-                       :to_io, :truncate, :tty?
+                       :fileno, :flush, :fsync, :internal_encoding,
+                       :isatty, :pid, :pos, :pos=, :reopen,
+                       :seek, :string, :sync, :sync=, :tell,
+                       :truncate, :tty?
+
+  def binmode?
+    !!(@io.binmode? if @io.respond_to?(:binmode?))
+  end
+
+  def flock(*args)
+    raise NotImplementedError unless @io.respond_to?(:flock)
+    @io.flock(*args)
+  end
+
+  def ioctl(*args)
+    raise NotImplementedError unless @io.respond_to?(:ioctl)
+    @io.ioctl(*args)
+  end
+
+  def path
+    @io.path if @io.respond_to?(:path)
+  end
+
+  def stat(*args)
+    raise NotImplementedError unless @io.respond_to?(:stat)
+    @io.stat(*args)
+  end
+
+  def to_i
+    raise NotImplementedError unless @io.respond_to?(:to_i)
+    @io.to_i
+  end
+
+  def to_io
+    @io.respond_to?(:to_io) ? @io.to_io : @io
+  end
 
   def eof?
     begin

--- a/test/csv/interface/test_delegation.rb
+++ b/test/csv/interface/test_delegation.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: false
+
+require_relative "../helper"
+
+class TestCSVInterfaceDelegation < Test::Unit::TestCase
+  def test_stringio_missing_methods_delegation
+    csv = CSV.new("h1,h2")
+
+    assert_raise(NotImplementedError) { csv.flock(0) }
+    assert_raise(NotImplementedError) { csv.ioctl(0) }
+    assert_raise(NotImplementedError) { csv.stat }
+    assert_raise(NotImplementedError) { csv.to_i }
+
+    assert_equal(false, csv.binmode?)
+    assert_equal(nil, csv.path)
+    assert_instance_of(StringIO, csv.to_io)
+  end
+end


### PR DESCRIPTION
If you create a `CSV` from raw content like:

    csv = CSV.new("h1,h2")

You'll get a `NoMethodError` when calling `csv.path` but still get true when
you call `csv.respond_to?(:path)`.

This tricks 3rd party libraries like `carrierwave` which try to call path
on their input, if it responds to it.

See https://github.com/carrierwaveuploader/carrierwave/blob/a91ab69fdd8052cdf5a5e48ef8baf40939e441fb/lib/carrierwave/sanitized_file.rb#L109-L123

This stops me from passing `CSV` objects as `StringIO`'s into `carrierwave`
uploads, for example, but the problem can also be manifested in other
3rd party libraries, as responding to a method and returning a
NoMethodError when calling it is still an unexpected behavior.

I have gone through the `CSV` delegation scheme and made sure that every
method that `StringIO` doesn't respond to returns a meaningful zero value
and does not raise a `NoMethodError` while used through a `CSV` Instance.

Ref. https://github.com/ruby/ruby/pull/2094