### PR TITLE
Add options "undef", "replace" form CSV#open

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -907,6 +907,13 @@ class CSV
   #                                       +true+, CSV will strip string. The
   #                                       length of string must be 1.
   #
+  # <b><tt>:undef</tt></b>::              When Converting encoding with 
+  #                                       "undef: :replace", you will replace
+  #                                       character to replace.
+  #                                       
+  # <b><tt>:replace</tt></b>::            Replace undef character to this value
+  #                                       
+  #
   # See CSV::DEFAULT_OPTIONS for the default settings.
   #
   # Options cannot be overridden in the instance methods for performance reasons,
@@ -936,7 +943,9 @@ class CSV
                  write_converters: nil,
                  write_nil_value: nil,
                  write_empty_value: "",
-                 strip: false)
+                 strip: false,
+                 undef: nil,
+                 replace: nil)
     raise ArgumentError.new("Cannot parse nil as CSV") if data.nil?
 
     # create the IO object we will read from

--- a/test/csv/interface/test_read.rb
+++ b/test/csv/interface/test_read.rb
@@ -264,6 +264,14 @@ class TestCSVInterfaceRead < Test::Unit::TestCase
     end
   end
 
+  def test_foreach_undef_replace
+    rows = []
+    CSV.foreach(@input.path, col_sep: "\t", row_sep: "\r\n", undef: :replace, replace: "*").each do |row|
+      rows << row
+    end
+    assert_equal(@rows, rows)
+  end
+
   def test_options_not_modified
     options = {}.freeze
     CSV.foreach(@input.path, options)


### PR DESCRIPTION
I want to use CSV#open with undef: :repace, replace: "*" options form wrong character.
