### PR TITLE
Fix typo in docs

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -200,7 +200,7 @@ using CSV::MatchP if CSV.const_defined?(:MatchP)
 #   data.first.to_h #=> {"Name"=>"Bob", "Department"=>"Engineering", "Salary"=>"1000"}
 #
 #   # Headers provided by developer
-#   data = CSV.parse('Bob,Engeneering,1000', headers: %i[name department salary])
+#   data = CSV.parse('Bob,Engineering,1000', headers: %i[name department salary])
 #   data.first      #=> #<CSV::Row name:"Bob" department:"Engineering" salary:"1000">
 #
 # === Typed data reading


### PR DESCRIPTION
This fix that the execution result of the next line is different from the actual result.