### PR TITLE
Suppress warnings

### DIFF
--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -14,6 +14,7 @@ class CSV
       @output = output
       @options = options
       @lineno = 0
+      @fields_converter = nil
       prepare
       if @options[:write_headers] and @headers
         self << @headers

--- a/test/csv/interface/test_read_write.rb
+++ b/test/csv/interface/test_read_write.rb
@@ -6,7 +6,6 @@ class TestCSVInterfaceReadWrite < Test::Unit::TestCase
   extend DifferentOFS
 
   def test_filter
-    rows = [[1, 2, 3], [4, 5]]
     input = <<-CSV
 1;2;3
 4;5


### PR DESCRIPTION
Suppress warnings in  verbose mode.

```
test/csv/interface/test_read_write.rb:9: warning: assigned but unused variable - rows
csv/lib/csv/writer.rb:35: warning: instance variable @fields_converter not initialized
```
