### PR TITLE
Fix `CSV#line` returns unexpected nil

### DIFF
--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -38,7 +38,7 @@ class CSV
 
       def keep_end
         start = @keeps.pop
-        string[start, pos - start]
+        string.byteslice(start, pos - start)
       end
 
       def keep_back
@@ -137,7 +137,7 @@ class CSV
 
       def keep_end
         start, buffer = @keeps.pop
-        keep = @scanner.string[start, @scanner.pos - start]
+        keep = @scanner.string.byteslice(start, @scanner.pos - start)
         if buffer
           buffer << keep
           keep = buffer

--- a/test/csv/test_features.rb
+++ b/test/csv/test_features.rb
@@ -124,10 +124,10 @@ line,4,jkl
 
   def test_line
     lines = [
-      %Q(abc,def\n),
-      %Q(abc,"d\nef"\n),
-      %Q(abc,"d\r\nef"\n),
-      %Q(abc,"d\ref")
+      %Q(\u{3000}abc,def\n),
+      %Q(\u{3000}abc,"d\nef"\n),
+      %Q(\u{3000}abc,"d\r\nef"\n),
+      %Q(\u{3000}abc,"d\ref")
     ]
     csv = CSV.new(lines.join(''))
     lines.each do |line|


### PR DESCRIPTION
Problem
----

Sometimes the `CSV#line` returns nil.

```
$ bin/console
> CSV.new(%Q(\u{3000}\u{3000}\u{3000}\n""""")).yield_self do |csv|
  csv.each { |_| }
rescue
  csv.line
end
=> nil

> CSV.new(%Q(\u{3000}\u{3000}\n""""")).yield_self do |csv|
  csv.each { |_| }
rescue
  csv.line
end
=> "\""
```

How to fix
----

The [`String#[]`](https://docs.ruby-lang.org/en/2.3.0/String.html#method-i-5B-5D) slices string by character size. (not bytesize)
So, in this case, I think it should use [`String#byteslice`](https://docs.ruby-lang.org/en/2.3.0/String.html#method-i-byteslice).

https://github.com/ruby/csv/blob/fb5dc364d0e8a861ca5e40b0cc3a374e8acffe74/lib/csv/parser.rb#L26-L42

Check
----

```
$ bin/console
> CSV.new(%Q(\u{3000}\u{3000}\u{3000}\n""""")).yield_self do |csv|
  csv.each { |_| }
rescue
  csv.line
end
=> "\"\"\"\"\""
> CSV.new(%Q(\u{3000}\u{3000}\n""""")).yield_self do |csv|
  csv.each { |_| }
rescue
  csv.line
end
=> "\"\"\"\"\""
```