### PR TITLE
Make CSV::Row#dup return a usable Row

### DIFF
--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -50,7 +50,11 @@ class CSV
 
     def initialize_copy(other)
       super
-      @row = @row.dup
+      @row = if other.headers.size >= other.fields.size
+               other.headers.zip(other.fields)
+             else
+               other.fields.zip(other.headers).each(&:reverse!)
+             end
     end
 
     # Returns +true+ if this is a header row.

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -50,11 +50,7 @@ class CSV
 
     def initialize_copy(other)
       super
-      @row = if other.headers.size >= other.fields.size
-               other.headers.zip(other.fields)
-             else
-               other.fields.zip(other.headers).each(&:reverse!)
-             end
+      @row = @row.collect(&:dup)
     end
 
     # Returns +true+ if this is a header row.

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -425,6 +425,9 @@ class TestCSVRow < Test::Unit::TestCase
   def test_dup
     row = CSV::Row.new(["A"], ["foo"])
     dupped_row = row.dup
+    dupped_row["A"] = "bar"
+    assert_equal(["foo", "bar"],
+                 [row["A"], dupped_row["A"]])
     dupped_row.delete("A")
     assert_equal(["foo", nil],
                  [row["A"], dupped_row["A"]])


### PR DESCRIPTION
Previously, calling `dup` on a `CSV::Row` object yielded an object whose
copy was too shallow. Changing the clone's fields would also change the
fields on the source. This change makes the clone more distinct from the
source, so that changes can be made to its fields without affecting the
source.