### PR TITLE
Do not loop forever when skip_lines regexp matches zero length with anchors

### DIFF
--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -769,7 +769,7 @@ class CSV
     def skip_needless_lines
       return unless @skip_lines
 
-      while true
+      until @scanner.eos?
         @scanner.keep_start
         line = @scanner.scan_all(@not_line_end) || "".encode(@encoding)
         line << @row_separator if parse_row_end
@@ -899,7 +899,7 @@ class CSV
             emit_row(row, &block)
             row = []
           end
-          skip_needless_lines unless @scanner.eos?
+          skip_needless_lines
           start_row
         elsif @scanner.eos?
           break if row.empty? and value.nil?

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -899,7 +899,7 @@ class CSV
             emit_row(row, &block)
             row = []
           end
-          skip_needless_lines
+          skip_needless_lines unless @scanner.eos?
           start_row
         elsif @scanner.eos?
           break if row.empty? and value.nil?

--- a/test/csv/parse/test_skip_lines.rb
+++ b/test/csv/parse/test_skip_lines.rb
@@ -102,10 +102,9 @@ class TestCSVParseSkipLines < Test::Unit::TestCase
                              :skip_lines => /\A#/))
     end
   end
-  
+
   def test_empty_anchored_regexp
     # protect against infinite loop
     assert_equal([[","]], CSV.parse(%[","\n], :skip_lines => /^$/))
   end
-    
 end

--- a/test/csv/parse/test_skip_lines.rb
+++ b/test/csv/parse/test_skip_lines.rb
@@ -103,8 +103,10 @@ class TestCSVParseSkipLines < Test::Unit::TestCase
     end
   end
 
-  def test_empty_anchored_regexp
-    # protect against infinite loop
-    assert_equal([[","]], CSV.parse(%[","\n], :skip_lines => /^$/))
+  def test_empty_line_and_liberal_parsing
+    assert_equal([["a", "b"]],
+                 CSV.parse("a,b\n",
+                           :liberal_parsing => true,
+                           :skip_lines => /^$/))
   end
 end

--- a/test/csv/parse/test_skip_lines.rb
+++ b/test/csv/parse/test_skip_lines.rb
@@ -102,4 +102,10 @@ class TestCSVParseSkipLines < Test::Unit::TestCase
                              :skip_lines => /\A#/))
     end
   end
+  
+  def test_empty_anchored_regexp
+    # protect against infinite loop
+    assert_equal([[","]], CSV.parse(%[","\n], :skip_lines => /^$/))
+  end
+    
 end


### PR DESCRIPTION
This started failing in v3.0.2.

There is a minimal repro case in the test.