### PR TITLE
Ensuring StringIO's encoding in CSV.generate

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -531,12 +531,13 @@ class CSV
     # plan to output non-ASCII compatible data.
     #
     def generate(str=nil, **options)
+      encoding = options[:encoding]
       # add a default empty String, if none was given
       if str
         str = StringIO.new(str)
         str.seek(0, IO::SEEK_END)
+        str.set_encoding(encoding) if encoding
       else
-        encoding = options[:encoding]
         str = +""
         str.force_encoding(encoding) if encoding
       end

--- a/test/csv/helper.rb
+++ b/test/csv/helper.rb
@@ -15,4 +15,28 @@ module Helper
       ENV["CSV_PARSER_SCANNER_TEST_CHUNK_SIZE"] = chunk_size_keep
     end
   end
+
+  def with_verbose(verbose)
+    original = $VERBOSE
+    begin
+      $VERBOSE = verbose
+      yield
+    ensure
+      $VERBOSE = original
+    end
+  end
+
+  def with_default_internal(encoding)
+    original = Encoding.default_internal
+    begin
+      with_verbose(false) do
+        Encoding.default_internal = encoding
+      end
+      yield
+    ensure
+      with_verbose(false) do
+        Encoding.default_internal = original
+      end
+    end
+  end
 end

--- a/test/csv/test_encodings.rb
+++ b/test/csv/test_encodings.rb
@@ -5,6 +5,7 @@ require_relative "helper"
 
 class TestCSVEncodings < Test::Unit::TestCase
   extend DifferentOFS
+  include Helper
 
   def setup
     super
@@ -247,6 +248,15 @@ class TestCSVEncodings < Test::Unit::TestCase
       csv << ["foo".force_encoding("ISO-8859-1"), "\u3042"]
     end
     assert_equal(["foo,\u3042\n".encode(Encoding::Windows_31J), Encoding::Windows_31J], [s, s.encoding], bug9766)
+  end
+
+  def test_encoding_with_default_internal
+    with_default_internal(Encoding::UTF_8) do
+      s = CSV.generate(String.new(encoding: Encoding::Big5), encoding: Encoding::Big5) do |csv|
+        csv << ["漢字"]
+      end
+      assert_equal(["漢字\n".encode(Encoding::Big5), Encoding::Big5], [s, s.encoding])
+    end
   end
 
   def test_row_separator_detection_with_invalid_encoding

--- a/test/csv/write/test_general.rb
+++ b/test/csv/write/test_general.rb
@@ -4,6 +4,8 @@
 require_relative "../helper"
 
 module TestCSVWriteGeneral
+  include Helper
+
   def test_tab
     assert_equal("\t#{$INPUT_RECORD_SEPARATOR}",
                  generate_line(["\t"]))
@@ -219,30 +221,6 @@ module TestCSVWriteGeneral
       row = ["あ", "い", "う"].collect {|field| field.encode("EUC-JP")}
       assert_equal(%Q[あ,い,う#{$INPUT_RECORD_SEPARATOR}].encode("EUC-JP"),
                    generate_line(row))
-    end
-  end
-
-  def with_verbose(verbose)
-    original = $VERBOSE
-    begin
-      $VERBOSE = verbose
-      yield
-    ensure
-      $VERBOSE = original
-    end
-  end
-
-  def with_default_internal(encoding)
-    original = Encoding.default_internal
-    begin
-      with_verbose(false) do
-        Encoding.default_internal = encoding
-      end
-      yield
-    ensure
-      with_verbose(false) do
-        Encoding.default_internal = original
-      end
     end
   end
 end


### PR DESCRIPTION
2.6

```
% ruby -EUTF-8:UTF-8 -ve 'require "csv"; p CSV.generate(String.new(encoding: Encoding::Big5), encoding: Encoding::Big5) {|csv| csv << ["漢字"] }.encoding'
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux]
#<Encoding:Big5>
```

master

```
% ruby -EUTF-8:UTF-8 -ve 'require "csv"; p CSV.generate(String.new(encoding: Encoding::Big5), encoding: Encoding::Big5) {|csv| csv << ["漢字"] }.encoding'
ruby 2.7.0dev (2019-11-23T07:06:30Z master b563439274) [x86_64-linux]
#<Encoding:UTF-8>
```

This branch

```
% bundle exec ruby -EUTF-8:UTF-8 -ve 'require "csv"; p CSV.generate(String.new(encoding: Encoding::Big5), encoding: Encoding::Big5) {|csv| csv << ["漢字"] }.encoding'
ruby 2.7.0dev (2019-11-23T07:06:30Z master b563439274) [x86_64-linux]
#<Encoding:Big5>
```