### PR TITLE
Keep buffers before calling CSV::Parser#emit_row inside of #parse_quotable_robust

### DIFF
--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -893,6 +893,8 @@ class CSV
         if parse_column_end
           row << value
         elsif parse_row_end
+          @scanner.keep_drop
+          @scanner.keep_start
           if row.empty? and value.nil?
             emit_row([], &block) unless @skip_blanks
           else
@@ -905,6 +907,8 @@ class CSV
         elsif @scanner.eos?
           break if row.empty? and value.nil?
           row << value
+          @scanner.keep_drop
+          @scanner.keep_start
           emit_row(row, &block)
           break
         else


### PR DESCRIPTION
## Probrem

`CSV#line` sometimes returns nil. It seems to be caused by empty lines within quoted columns.
(I have not been reproduce the error yet with a minimum CSV which contains a column to be caused. Sorry.)

## How to fix

In the `Parser#parse_quotable_loose`, the `@scanner.keep_drop` and the `@scanner.keep_start` are called before calling the `Parser#emit_row`. but there are no calls them the same way in the `Parser#parse_quotable_robust`.

- `Parser#parse_quotable_loose`
 https://github.com/ruby/csv/blob/398b3564c5b0de78552dfad1b4f26013bf21bdba/lib/csv/parser.rb#L869-L872
- `Parser#parse_quotable_robust`
https://github.com/ruby/csv/blob/398b3564c5b0de78552dfad1b4f26013bf21bdba/lib/csv/parser.rb#L896-L909

So I guess that calling the `@scanner.keep_drop` and the `@scanner.keep_start` as well in the `Parser#parse_quotable_robust`, it will be able to ensure getting a line through `Parser#last_line`.