### PR TITLE
Add `invalid: :replace` for `CSV.open`

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -962,8 +962,10 @@ class CSV
     #
     # possible options elements:
     #   hash form:
-    #     :undef => :replace # replace undefined conversion
-    #     :replace => string # replacement string ("?" or "\uFFFD" if not specified)
+    #     :invalid => nil      # raise error on invalid byte sequence (default)
+    #     :invalid => :replace # replace invalid byte sequence
+    #     :undef => :replace   # replace undefined conversion
+    #     :replace => string   # replacement string ("?" or "\uFFFD" if not specified)
     #
     # This method opens an IO object, and wraps that with CSV. This is intended
     # as the primary interface for writing a CSV file.
@@ -1026,6 +1028,7 @@ class CSV
       # wrap a File opened with the remaining +args+ with no newline
       # decorator
       file_opts = {universal_newline: false}.merge(options)
+      options.delete(:invalid)
       options.delete(:undef)
       options.delete(:replace)
 


### PR DESCRIPTION
This PR adds `invalid: :replace` for `CSV.open`. It is a PR similar to #129.
