### PR TITLE
Fix an error for `CSV.open`

### DIFF
--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -156,7 +156,7 @@ class CSV
         else
           field = String(field)  # Stringify fields
           # represent empty fields as empty quoted fields
-          if (@quote_empty and field.empty?) or @quotable_pattern.match?(field)
+          if (@quote_empty and field.empty?) or (field.valid_encoding? and @quotable_pattern.match?(field))
             quote_field(field)
           else
             field  # unquoted field

--- a/test/csv/interface/test_read.rb
+++ b/test/csv/interface/test_read.rb
@@ -125,6 +125,16 @@ class TestCSVInterfaceRead < Test::Unit::TestCase
     end
   end
 
+  def test_open_invalid_byte_sequence_in_utf_8
+    CSV.open(@input.path, "w", encoding: Encoding::CP932) do |rows|
+      error = assert_raise(Encoding::InvalidByteSequenceError) do
+        rows << ["\x82\xa0"]
+      end
+      assert_equal('"\x82" on UTF-8',
+                   error.message)
+    end
+  end
+
   def test_open_with_undef_replace
     # U+00B7 Middle Dot
     CSV.open(@input.path, "w", encoding: Encoding::CP932, undef: :replace) do |rows|


### PR DESCRIPTION
Follow up to https://github.com/ruby/csv/pull/130/files#r434885191.

This PR fixes `ArgumentError` for `CSV.open` when processing invalid byte sequence in UTF-8.