### PR TITLE
Bump minimum ruby version to 2.5.0

### DIFF
--- a/csv.gemspec
+++ b/csv.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   ]
   spec.extra_rdoc_files = rdoc_files
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "stringio", ">= 0.1.3"
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
A dependency to stringio was added to csv, which requires Ruby version >= 2.5. Bump the gemspec version accordingly.