### PR TITLE
Allow :newline option to CSV.open

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1430,7 +1430,7 @@ class CSV
       options.delete(:invalid)
       options.delete(:undef)
       options.delete(:replace)
-      options.delete_if {|k, _| /newline\z/ =~ k}
+      options.delete_if {|k, _| /newline\z/.match?(k)}
 
       begin
         f = File.open(filename, mode, **file_opts)

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1423,10 +1423,14 @@ class CSV
     def open(filename, mode="r", **options)
       # wrap a File opened with the remaining +args+ with no newline
       # decorator
-      file_opts = {universal_newline: false}.merge(options)
+      file_opts = options.dup
+      unless file_opts.key?(:newline)
+        file_opts[:universal_newline] ||= false
+      end
       options.delete(:invalid)
       options.delete(:undef)
       options.delete(:replace)
+      options.delete_if {|k, _| /newline\z/ =~ k}
 
       begin
         f = File.open(filename, mode, **file_opts)

--- a/test/csv/interface/test_read.rb
+++ b/test/csv/interface/test_read.rb
@@ -191,9 +191,7 @@ class TestCSVInterfaceRead < Test::Unit::TestCase
     CSV.open(@input.path, col_sep: "\t", universal_newline: true) do |csv|
       assert_equal(@rows, csv.to_a)
     end
-    File.open(@input.path, "w") do |file|
-      file << "1,2,3\r\n" "4,5\n"
-    end
+    File.binwrite(@input.path, "1,2,3\r\n" "4,5\n")
     CSV.open(@input.path, newline: :universal) do |csv|
       assert_equal(@rows, csv.to_a)
     end

--- a/test/csv/interface/test_read.rb
+++ b/test/csv/interface/test_read.rb
@@ -187,6 +187,18 @@ class TestCSVInterfaceRead < Test::Unit::TestCase
     end
   end
 
+  def test_open_with_newline
+    CSV.open(@input.path, col_sep: "\t", universal_newline: true) do |csv|
+      assert_equal(@rows, csv.to_a)
+    end
+    File.open(@input.path, "w") do |file|
+      file << "1,2,3\r\n" "4,5\n"
+    end
+    CSV.open(@input.path, newline: :universal) do |csv|
+      assert_equal(@rows, csv.to_a)
+    end
+  end
+
   def test_parse
     assert_equal(@rows,
                  CSV.parse(@data, col_sep: "\t", row_sep: "\r\n"))


### PR DESCRIPTION
As `:newline` has priority over `:universal_newline` etc. in `IO.open`, so deal with both.
On the other hand, such options cannot be passed to `CSV#initialize`.
