### PR TITLE
Implement unused #.empty? meth & clean up booleans

### DIFF
--- a/lib/csv/fields_converter.rb
+++ b/lib/csv/fields_converter.rb
@@ -72,13 +72,12 @@ class CSV
     end
 
     private
-    def need_static_convert?
-      not (@nil_value.nil? and @empty_value_is_empty_string)
+    def need_convert?
+      values_exist? or not empty?
     end
 
-    def need_convert?
-      @need_static_convert or
-        (not @converters.empty?)
+    def values_exist?
+      not (@nil_value.nil? and @empty_value_is_empty_string)
     end
   end
 end


### PR DESCRIPTION
Noticed this boolean was using a large amount of chained negative statements.

Figured a simpler implementation would be good for readers.

Sidenote: #.empty? method on this class was written but not implemented, but for this case is perf so used it.

![image](https://user-images.githubusercontent.com/46613794/110460943-d4e59000-809c-11eb-8d12-a14143131c32.png)
