### PR TITLE
CI: Avoid Float 3.0 in YAML

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,13 +12,13 @@ jobs:
       matrix:
         ruby-version:
           - 2.7
-          - 3.0
+          - '3.0'
         runs-on:
           - macos-latest
           - ubuntu-latest
           - windows-latest
         exclude:
-          - { runs-on: windows-latest , ruby-version: 3.0 }
+          - { runs-on: windows-latest , ruby-version: '3.0' }
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,14 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
           - debug
         runs-on:
           - macos-latest
           - ubuntu-latest
           - windows-latest
         exclude:
-          - { runs-on: windows-latest , ruby-version: 3.0 }
+          - { runs-on: windows-latest , ruby-version: '3.0' }
           - { runs-on: windows-latest , ruby-version: debug }
         include:
           - { runs-on: windows-latest , ruby-version: mingw }
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - 3.0
+          - '3.0'
           - 2.7
           - debug
         runs-on:
@@ -54,7 +54,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         exclude:
-          - { runs-on: windows-latest , ruby-version: 3.0 }
+          - { runs-on: windows-latest , ruby-version: '3.0' }
           - { runs-on: windows-latest , ruby-version: debug }
         include:
           - { runs-on: windows-latest , ruby-version: mingw }


### PR DESCRIPTION
Add quotes around "3.0" in YAML to avoid the issue reported in https://github.com/actions/runner/issues/849.