### PR TITLE
Fix for parser getting confused after faulty row with CRLF line ending. 

### DIFF
--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -527,7 +527,7 @@ class CSV
 
       @cr = "\r".encode(@encoding)
       @lf = "\n".encode(@encoding)
-      @cr_or_lf = Regexp.new("[\r\n]".encode(@encoding))
+      @line_end = Regexp.new("\r\n|\n|\r".encode(@encoding))
       @not_line_end = Regexp.new("[^\r\n]+".encode(@encoding))
     end
 
@@ -915,7 +915,7 @@ class CSV
             message = "Any value after quoted field isn't allowed"
             raise MalformedCSVError.new(message, @lineno)
           elsif @unquoted_column_value and
-                (new_line = @scanner.scan(@cr_or_lf))
+                (new_line = @scanner.scan(@line_end))
             ignore_broken_line
             message = "Unquoted fields do not allow new line " +
                       "<#{new_line.inspect}>"
@@ -924,7 +924,7 @@ class CSV
             ignore_broken_line
             message = "Illegal quoting"
             raise MalformedCSVError.new(message, @lineno)
-          elsif (new_line = @scanner.scan(@cr_or_lf))
+          elsif (new_line = @scanner.scan(@line_end))
             ignore_broken_line
             message = "New line must be <#{@row_separator.inspect}> " +
                       "not <#{new_line.inspect}>"
@@ -1090,7 +1090,7 @@ class CSV
 
     def ignore_broken_line
       @scanner.scan_all(@not_line_end)
-      @scanner.scan_all(@cr_or_lf)
+      @scanner.scan_all(@line_end)
       @lineno += 1
     end
 

--- a/test/csv/parse/test_invalid.rb
+++ b/test/csv/parse/test_invalid.rb
@@ -36,4 +36,17 @@ ggg,hhh,iii
                  csv.shift)
     assert_equal(true, csv.eof?)
   end
+
+  def test_ignore_invalid_line_cr_lf
+    data = <<-CSV
+"1","OK"\r
+"2",""NOT" OK"\r
+"3","OK"\r
+CSV
+    csv = CSV.new(data)
+
+    assert_equal(['1', 'OK'], csv.shift)
+    assert_raise(CSV::MalformedCSVError) { csv.shift }
+    assert_equal(['3', 'OK'], csv.shift)
+  end
 end


### PR DESCRIPTION
It looks like the parser is currently not able to fully ignore a broken line because of the regex used for detecting the line ending in the file. The current behaviour will move the parser to the first `\r` char in the line. But for files using CRLF as line endings that is not enough.

This PR changes the detection to consider the combinations `\r\n` or `\r` or `\n` when ignoring a broken line.

