### PR TITLE
Fix case where an \r\n row separator will be split when reading a chunk

### DIFF
--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -235,6 +235,9 @@ class CSV
         else
           chunk = input.gets(nil, @chunk_size)
           if chunk
+            if chunk[-1] == "\r" && (maybe_newline = input.gets(nil, 1))
+              chunk << maybe_newline
+            end
             raise InvalidEncoding unless chunk.valid_encoding?
             @scanner = StringScanner.new(chunk)
             if input.respond_to?(:eof?) and input.eof?


### PR DESCRIPTION
In this case, read one more character.

This is a suboptimal fix, as it doesn't fix handling of row
separators that aren't two characters and starting with \r.
A better fix would handle all multibyte row separators.
However, as \r\n is one of the most common row separators,
I think it's useful to merge this until a more generic
solution is developed.

Fixes [Bug #18245]