### PR TITLE
Add handling for ambiguous parsing options

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -366,8 +366,9 @@ using CSV::MatchP if CSV.const_defined?(:MatchP)
 # - +header_converters+: Specifies the header converters to be used.
 # - +skip_blanks+: Specifies whether blanks lines are to be ignored.
 # - +skip_lines+: Specifies how comments lines are to be recognized.
-# - +strip+: Specifies whether leading and trailing whitespace are
-#   to be stripped from fields.
+# - +strip+: Specifies whether leading and trailing whitespace are to be
+#   stripped from fields. This must be compatible with +col_sep+; if it is not,
+#   then an +ArgumentError+ exception will be raised.
 # - +liberal_parsing+: Specifies whether \CSV should attempt to parse
 #   non-compliant data.
 # - +nil_value+: Specifies the object that is to be substituted for each null (no-text) field.

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -341,6 +341,7 @@ using CSV::MatchP if CSV.const_defined?(:MatchP)
 #     liberal_parsing:    false,
 #     nil_value:          nil,
 #     empty_value:        "",
+#     strip:              false,
 #     # For generating.
 #     write_headers:      nil,
 #     quote_empty:        true,
@@ -348,7 +349,6 @@ using CSV::MatchP if CSV.const_defined?(:MatchP)
 #     write_converters:   nil,
 #     write_nil_value:    nil,
 #     write_empty_value:  "",
-#     strip:              false,
 #   }
 #
 # ==== Options for Parsing
@@ -367,7 +367,7 @@ using CSV::MatchP if CSV.const_defined?(:MatchP)
 # - +skip_blanks+: Specifies whether blanks lines are to be ignored.
 # - +skip_lines+: Specifies how comments lines are to be recognized.
 # - +strip+: Specifies whether leading and trailing whitespace are
-#   to be stripped from fields..
+#   to be stripped from fields.
 # - +liberal_parsing+: Specifies whether \CSV should attempt to parse
 #   non-compliant data.
 # - +nil_value+: Specifies the object that is to be substituted for each null (no-text) field.
@@ -946,6 +946,7 @@ class CSV
     liberal_parsing:    false,
     nil_value:          nil,
     empty_value:        "",
+    strip:              false,
     # For generating.
     write_headers:      nil,
     quote_empty:        true,
@@ -953,7 +954,6 @@ class CSV
     write_converters:   nil,
     write_nil_value:    nil,
     write_empty_value:  "",
-    strip:              false,
   }.freeze
 
   class << self
@@ -1879,11 +1879,11 @@ class CSV
                  encoding: nil,
                  nil_value: nil,
                  empty_value: "",
+                 strip: false,
                  quote_empty: true,
                  write_converters: nil,
                  write_nil_value: nil,
-                 write_empty_value: "",
-                 strip: false)
+                 write_empty_value: "")
     raise ArgumentError.new("Cannot parse nil as CSV") if data.nil?
 
     if data.is_a?(String)

--- a/test/csv/parse/test_strip.rb
+++ b/test/csv/parse/test_strip.rb
@@ -80,4 +80,33 @@ class TestCSVParseStrip < Test::Unit::TestCase
                            %Q{"a" ,"b " \r\n},
                            strip: true))
   end
+
+  def test_col_sep_incompatible_true
+    message = "The provided strip (true) and " \
+              "col_sep (\\t) options are incompatible."
+    assert_raise_with_message(ArgumentError, message) do
+      CSV.parse_line(%Q{"a"\t"b"\n},
+                     col_sep: "\t",
+                     strip: true)
+    end
+  end
+
+  def test_col_sep_incompatible_string
+    message = "The provided strip (\\t) and " \
+              "col_sep (\\t) options are incompatible."
+    assert_raise_with_message(ArgumentError, message) do
+      CSV.parse_line(%Q{"a"\t"b"\n},
+                     col_sep: "\t",
+                     strip: "\t")
+    end
+  end
+
+  def test_col_sep_compatible_string
+    assert_equal(
+      ["a", "b"],
+      CSV.parse_line(%Q{\va\tb\v\n},
+                     col_sep: "\t",
+                     strip: "\v")
+    )
+  end
 end


### PR DESCRIPTION
This pull request addresses [this bug report](https://github.com/ruby/csv/issues/225).

Let me know if there are any issues or places where I can improve it!