### PR TITLE
Add contents summary to CSV::Table#inspect

### DIFF
--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -1000,9 +1000,7 @@ class CSV
     # (see {Option +write_headers+}[../CSV.html#class-CSV-label-Option+write_headers]):
     #   table.to_csv(write_headers: false) # => "foo,0\nbar,1\nbaz,2\n"
     #
-    # Limit rows if option +limit+ is given like +2+
-    #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
-    #   table = CSV.parse(source, headers: true)
+    # Limit rows if option +limit+ is given like +2+:
     #   table.to_csv(limit: 2) # => "Name,Value\nfoo,0\nbar,1\n"
     def to_csv(write_headers: true, limit: nil, **options)
       array = write_headers ? [headers.to_csv(**options)] : []

--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -1028,14 +1028,17 @@ class CSV
     end
 
     # :call-seq:
-    #   table.inspect(row_counts) -> self
+    #   table.inspect() => string
     #
-    # Return table with specified rows data with header
+    # Returns a table with specified rows data with header
     #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
     #   table = CSV.parse(source, headers: true)
-    #   table.inspect(2) # => #<CSV::Row "Name":"foo" "Value":"0">, #<CSV::Row "Name":"bar" "Value":"1">
     #
-    def inspect(row_counts)
+    # Example:
+    #   table.inspect() # => #<CSV::Row "Name":"foo" "Value":"0">, #<CSV::Row "Name":"bar" "Value":"1">
+    #
+    def inspect()
+      row_counts = 5
       array = [headers.to_csv]
       if row_counts.nil?
         return array.join("")

--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -999,9 +999,11 @@ class CSV
     # Omits the headers if option +write_headers+ is given as +false+
     # (see {Option +write_headers+}[../CSV.html#class-CSV-label-Option+write_headers]):
     #   table.to_csv(write_headers: false) # => "foo,0\nbar,1\nbaz,2\n"
-    def to_csv(write_headers: true, **options)
+    def to_csv(write_headers: true, limit: nil, **options)
       array = write_headers ? [headers.to_csv(**options)] : []
-      @table.each do |row|
+      limit ||= @table.size
+      limit = @table.size + 1 + limit if limit < 0
+      @table.first(limit).each do |row|
         array.push(row.fields.to_csv(**options)) unless row.header_row?
       end
 
@@ -1028,7 +1030,7 @@ class CSV
     end
 
     # :call-seq:
-    #   table.inspect() => string
+    #   table.inspect => string
     #
     # Returns a table with specified rows data with header
     #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
@@ -1037,16 +1039,11 @@ class CSV
     # Example:
     #   table.inspect() # => #<CSV::Row "Name":"foo" "Value":"0">, #<CSV::Row "Name":"bar" "Value":"1">
     #
-    def inspect()
-      row_counts = 5
-      array = [headers.to_csv]
-      if row_counts.nil?
-        return array.join("")
-      end
-      @table.first(row_counts).each do |row|
-        array.push(row.fields.to_csv) unless row.header_row?
-      end
-      array.join("")
+    def inspect
+      inspected = +"#<#{self.class} mode:#{@mode} row_count:#{to_a.size}>"
+      summary = to_csv(limit: 5)
+      inspected << "\n" << summary if summary.encoding.ascii_compatible?
+      inspected
     end
   end
 end

--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -1032,12 +1032,15 @@ class CSV
     # :call-seq:
     #   table.inspect => string
     #
-    # Returns a table with specified rows data with header
-    #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
-    #   table = CSV.parse(source, headers: true)
+    # Returns a <tt>US-ASCII</tt>-encoded \String showing table:
+    # - Class: <tt>CSV::Table</tt>.
+    # - Access mode: <tt>:row</tt>, <tt>:col</tt>, or <tt>:col_or_row</tt>.
+    # - Size:  Row count, including the header row.
     #
     # Example:
-    #   table.inspect() # => #<CSV::Row "Name":"foo" "Value":"0">, #<CSV::Row "Name":"bar" "Value":"1">
+    #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+    #   table = CSV.parse(source, headers: true)
+    #   table.inspect # => "#<CSV::Table mode:col_or_row row_count:4>\nName,Value\nfoo,0\nbar,1\nbaz,2\n"
     #
     def inspect
       inspected = +"#<#{self.class} mode:#{@mode} row_count:#{to_a.size}>"

--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -999,6 +999,16 @@ class CSV
     # Omits the headers if option +write_headers+ is given as +false+
     # (see {Option +write_headers+}[../CSV.html#class-CSV-label-Option+write_headers]):
     #   table.to_csv(write_headers: false) # => "foo,0\nbar,1\nbaz,2\n"
+    #
+    # Defaults option +limit+ to +nil+:
+    #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+    #   table = CSV.parse(source, headers: true)
+    #   table.to_csv # => "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+    #
+    # Limit rows if option +limit+ is given like +2+
+    #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+    #   table = CSV.parse(source, limit: 2, headers: true)
+    #   table.to_csv # => "Name,Value\nfoo,0\nbar,1\n"
     def to_csv(write_headers: true, limit: nil, **options)
       array = write_headers ? [headers.to_csv(**options)] : []
       limit ||= @table.size

--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -1000,15 +1000,10 @@ class CSV
     # (see {Option +write_headers+}[../CSV.html#class-CSV-label-Option+write_headers]):
     #   table.to_csv(write_headers: false) # => "foo,0\nbar,1\nbaz,2\n"
     #
-    # Defaults option +limit+ to +nil+:
-    #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
-    #   table = CSV.parse(source, headers: true)
-    #   table.to_csv # => "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
-    #
     # Limit rows if option +limit+ is given like +2+
     #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
-    #   table = CSV.parse(source, limit: 2, headers: true)
-    #   table.to_csv # => "Name,Value\nfoo,0\nbar,1\n"
+    #   table = CSV.parse(source, headers: true)
+    #   table.to_csv(limit: 2) # => "Name,Value\nfoo,0\nbar,1\n"
     def to_csv(write_headers: true, limit: nil, **options)
       array = write_headers ? [headers.to_csv(**options)] : []
       limit ||= @table.size

--- a/lib/csv/table.rb
+++ b/lib/csv/table.rb
@@ -1028,19 +1028,22 @@ class CSV
     end
 
     # :call-seq:
-    #   table.inspect => string
+    #   table.inspect(row_counts) -> self
     #
-    # Returns a <tt>US-ASCII</tt>-encoded \String showing table:
-    # - Class: <tt>CSV::Table</tt>.
-    # - Access mode: <tt>:row</tt>, <tt>:col</tt>, or <tt>:col_or_row</tt>.
-    # - Size:  Row count, including the header row.
-    #
-    # Example:
+    # Return table with specified rows data with header
     #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
     #   table = CSV.parse(source, headers: true)
-    #   table.inspect # => "#<CSV::Table mode:col_or_row row_count:4>"
-    def inspect
-      "#<#{self.class} mode:#{@mode} row_count:#{to_a.size}>".encode("US-ASCII")
+    #   table.inspect(2) # => #<CSV::Row "Name":"foo" "Value":"0">, #<CSV::Row "Name":"bar" "Value":"1">
+    #
+    def inspect(row_counts)
+      array = [headers.to_csv]
+      if row_counts.nil?
+        return array.join("")
+      end
+      @table.first(row_counts).each do |row|
+        array.push(row.fields.to_csv) unless row.header_row?
+      end
+      array.join("")
     end
   end
 end

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -16,7 +16,7 @@ class TestCSVTable < Test::Unit::TestCase
     @header_table = CSV::Table.new(
       [CSV::Row.new(%w{A B C}, %w{A B C}, true)] + @rows
     )
-    
+
     @header_only_table = CSV::Table.new([], headers: %w{A B C})
   end
 
@@ -552,20 +552,22 @@ A
     assert_equal(@rows.size, @table.size)
   end
 
-  def test_inspect_shows_current_mode
-    str = @table.inspect
-    assert_include(str, "mode:#{@table.mode}", "Mode not shown.")
-
-    @table.by_col!
-    str = @table.inspect
-    assert_include(str, "mode:#{@table.mode}", "Mode not shown.")
+  def test_inspect_nil
+    row_counts = nil
+    table = @table.inspect(row_counts)
+    assert_equal(<<-CSV, table)
+A,B,C
+    CSV
   end
 
-  def test_inspect_encoding_is_ascii_compatible
-    assert_send([Encoding, :compatible?,
-                 Encoding.find("US-ASCII"),
-                 @table.inspect.encoding],
-            "inspect() was not ASCII compatible." )
+  def test_inspect_limited_row
+    row_counts = 4
+    table = @table.inspect(row_counts)
+    assert_equal(<<-CSV, table)
+A,B,C
+1,2,3
+4,5,6
+    CSV
   end
 
   def test_dig_mixed

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -561,7 +561,7 @@ A,B,C
   end
 
   def test_inspect_limited_row
-    row_counts = 4
+    row_counts = 2
     table = @table.inspect(row_counts)
     assert_equal(<<-CSV, table)
 A,B,C

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -552,6 +552,22 @@ A
     assert_equal(@rows.size, @table.size)
   end
 
+  def test_inspect_shows_current_mode
+    str = @table.inspect
+    assert_include(str, "mode:#{@table.mode}", "Mode not shown.")
+
+    @table.by_col!
+    str = @table.inspect
+    assert_include(str, "mode:#{@table.mode}", "Mode not shown.")
+  end
+
+  def test_inspect_encoding_is_ascii_compatible
+    assert_send([Encoding, :compatible?,
+                 Encoding.find("US-ASCII"),
+                 @table.inspect.encoding],
+                "inspect() was not ASCII compatible." )
+  end
+  
   def test_inspect_nil
     row_counts = nil
     table = @table.inspect(row_counts)

--- a/test/csv/test_table.rb
+++ b/test/csv/test_table.rb
@@ -567,22 +567,22 @@ A
                  @table.inspect.encoding],
                 "inspect() was not ASCII compatible." )
   end
-  
-  def test_inspect_nil
-    row_counts = nil
-    table = @table.inspect(row_counts)
-    assert_equal(<<-CSV, table)
-A,B,C
-    CSV
-  end
 
-  def test_inspect_limited_row
-    row_counts = 2
-    table = @table.inspect(row_counts)
-    assert_equal(<<-CSV, table)
+  def test_inspect_with_rows
+    additional_rows  = [ CSV::Row.new(%w{A B C}, [101, 102, 103]),
+                         CSV::Row.new(%w{A B C}, [104, 105, 106]),
+                         CSV::Row.new(%w{A B C}, [107, 108, 109]) ]
+    table = CSV::Table.new(@rows + additional_rows)
+    str_table = table.inspect
+
+    assert_equal(<<-CSV, str_table)
+#<CSV::Table mode:col_or_row row_count:7>
 A,B,C
 1,2,3
 4,5,6
+7,8,9
+101,102,103
+104,105,106
     CSV
   end
 


### PR DESCRIPTION
I thought that it is useful for us if this library has a function to return some rows results as a table.
So changed the method to return a table with a header and rows.