### PR TITLE
Improve error reporting for liberal parsing with quoted values

### DIFF
--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -229,7 +229,7 @@ class CSV
 
       def keep_drop
         _, _, buffer = @keeps.pop
-        # trace(__method__, :done, :emtpy) unless buffer
+        # trace(__method__, :done, :empty) unless buffer
         return unless buffer
 
         last_keep = @keeps.last
@@ -246,6 +246,10 @@ class CSV
 
       def rest
         @scanner.rest
+      end
+
+      def check(pattern)
+        @scanner.check(pattern)
       end
 
       private
@@ -1022,10 +1026,10 @@ class CSV
           break
         else
           if @quoted_column_value
-            message = if liberal_parsing? and (new_line = @scanner.scan(@line_end))
-              "Illegal end-of-line sequence outside of a quoted field " + "<#{new_line.inspect}>"
+            if liberal_parsing? and (new_line = @scanner.check(@line_end))
+              message = "Illegal end-of-line sequence outside of a quoted field " + "<#{new_line.inspect}>"
             else
-              "Any value after quoted field isn't allowed"
+              message = "Any value after quoted field isn't allowed"
             end
             ignore_broken_line
             raise MalformedCSVError.new(message, @lineno)

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -1022,8 +1022,12 @@ class CSV
           break
         else
           if @quoted_column_value
+            message = if liberal_parsing? and (new_line = @scanner.scan(@line_end))
+              "Illegal end-of-line sequence outside of a quoted field " + "<#{new_line.inspect}>"
+            else
+              "Any value after quoted field isn't allowed"
+            end
             ignore_broken_line
-            message = "Any value after quoted field isn't allowed"
             raise MalformedCSVError.new(message, @lineno)
           elsif @unquoted_column_value and
                 (new_line = @scanner.scan(@line_end))

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -28,6 +28,15 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
                  CSV.parse_line(input, liberal_parsing: true))
   end
 
+  def test_endline_after_quoted_field_end
+    input = "A\n\"B\"\r\n"
+    error = assert_raise(CSV::MalformedCSVError) do
+      CSV.parse(input, liberal_parsing: true)
+    end
+    assert_equal('Illegal end-of-line sequence outside of a quoted field <"\r\n"> in line 2.',
+                 error.message)
+  end
+
   def test_quote_after_column_separator
     error = assert_raise(CSV::MalformedCSVError) do
       CSV.parse_line('is,this "three," or four,fields', liberal_parsing: true)

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -29,11 +29,11 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
   end
 
   def test_endline_after_quoted_field_end
-    input = "A\n\"B\"\r\n"
+    input = "A\r\n\"B\"\n"
     error = assert_raise(CSV::MalformedCSVError) do
       CSV.parse(input, liberal_parsing: true)
     end
-    assert_equal('Illegal end-of-line sequence outside of a quoted field <"\r\n"> in line 2.',
+    assert_equal('Illegal end-of-line sequence outside of a quoted field <"\n"> in line 2.',
                  error.message)
   end
 

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -29,9 +29,8 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
   end
 
   def test_endline_after_quoted_field_end
-    input = "A\r\n\"B\"\n"
     error = assert_raise(CSV::MalformedCSVError) do
-      CSV.parse(input, liberal_parsing: true)
+      CSV.parse("A\r\n\"B\"\n", liberal_parsing: true)
     end
     assert_equal('Illegal end-of-line sequence outside of a quoted field <"\n"> in line 2.',
                  error.message)

--- a/test/csv/parse/test_liberal_parsing.rb
+++ b/test/csv/parse/test_liberal_parsing.rb
@@ -29,11 +29,14 @@ class TestCSVParseLiberalParsing < Test::Unit::TestCase
   end
 
   def test_endline_after_quoted_field_end
+    csv = CSV.new("A\r\n\"B\"\nC\r\n", liberal_parsing: true)
+    assert_equal(["A"], csv.gets)
     error = assert_raise(CSV::MalformedCSVError) do
-      CSV.parse("A\r\n\"B\"\n", liberal_parsing: true)
+      csv.gets
     end
     assert_equal('Illegal end-of-line sequence outside of a quoted field <"\n"> in line 2.',
                  error.message)
+    assert_equal(["C"], csv.gets)
   end
 
   def test_quote_after_column_separator


### PR DESCRIPTION
In cases when `liberal_parsing` is used with quoted values in a file that has mixed up EOL terminators, this lib produces a meaningless error: 
```
# Normal parsing, no quotes (makes sense)
CSV.parse("A\nB\r\n")
=> CSV::MalformedCSVError: Unquoted fields do not allow new line <"\r\n"> in line 2.
```
```
# Normal parsing, with quotes (kinda makes sense - not super-helpful, but technically correct)
CSV.parse("A\n\"B\"\r\n")
CSV::MalformedCSVError: Any value after quoted field isn't allowed in line 2.
```
```
# Liberal parsing, no quotes ( makes sense)
CSV.parse("A\nB\r\n", liberal_parsing: true)
CSV::MalformedCSVError: Unquoted fields do not allow new line <"\r\n"> in line 2.
```
```
# Liberal parsing, with quotes (misleading)
CSV.parse("A\n\"B\"\r\n", liberal_parsing: true)
CSV::MalformedCSVError: Any value after quoted field isn't allowed in line 2.
```
The last one is highly misleading because liberal parsing does indeed allow values after a quoted field, that is its whole purpose. In addition, there is no information about the actual source of the problem - the wrong newline sequence. 
I personally wasted a lot of time debugging this issue, when received a file with mixed up newline sequences.

This PR adds a separate error message for this case 