### PR TITLE
Improve $INPUT_RECORD_SEPARATOR deprecation check

### DIFF
--- a/lib/csv/input_record_separator.rb
+++ b/lib/csv/input_record_separator.rb
@@ -5,16 +5,23 @@ class CSV
   module InputRecordSeparator
     class << self
       is_input_record_separator_deprecated = false
-      verbose, $VERBOSE = $VERBOSE, true
-      stderr, $stderr = $stderr, StringIO.new
-      input_record_separator = $INPUT_RECORD_SEPARATOR
-      begin
-        $INPUT_RECORD_SEPARATOR = "\r\n"
-        is_input_record_separator_deprecated = (not $stderr.string.empty?)
-      ensure
-        $INPUT_RECORD_SEPARATOR = input_record_separator
-        $stderr = stderr
-        $VERBOSE = verbose
+      if defined?(::Warning) # Warning was introduced in 2.4, $INPUT_RECORD_SEPARATOR was deprecated in 3.0
+        original_method = ::Warning.singleton_class.instance_method(:warn)
+        ::Warning.singleton_class.alias_method(:warn, :warn)
+        begin
+          ::Warning.singleton_class.define_method(:warn) do |message, *args, **kwargs|
+            if message.include?("`$INPUT_RECORD_SEPARATOR' is deprecated")
+              is_input_record_separator_deprecated = true
+            else
+              # If somehow we caught an unexpected warning, we call back the original method.
+              original_method.bind(self).call(message, *args, **kwargs)
+            end
+          end
+          $INPUT_RECORD_SEPARATOR = $INPUT_RECORD_SEPARATOR # trigger the deprecation warning
+        ensure
+          ::Warning.singleton_class.alias_method(:warn, :warn)
+          ::Warning.singleton_class.define_method(:warn, original_method)
+        end
       end
 
       if is_input_record_separator_deprecated


### PR DESCRIPTION
Ref: https://github.com/casperisfine/csv/commit/1f9cbc170ea4f3d9a9db48d12bcf9895bfe86c25

Setting `$VERBOSE = false` is not quite enough because some applications
define `Warning.warn` to collect and process warnings beyond just priting
them on STDERR.

For instance some apps might translate warnings into errors:

```ruby
def Warning.warn(message)
  raise Deprecated, message
end
```

So hooking into `Warning.warn` to catch the deprecation warning is much less likely to cause issues.

cc @kou 