### PR TITLE
Add support for RFC 3339 style time

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -875,9 +875,9 @@ class CSV
   # A Regexp used to find and convert some common DateTime formats.
   DateTimeMatcher =
     / \A(?: (\w+,?\s+)?\w+\s+\d{1,2}\s+\d{1,2}:\d{1,2}:\d{1,2},?\s+\d{2,4} |
-            # ISO-8601 and near-ISO (space instead of T) recognized by DateTime.parse
+            # ISO-8601 and RFC-3339 (space instead of T) recognized by DateTime.parse
             \d{4}-\d{2}-\d{2}
-              (?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?(?:[+-]\d{2}(?::\d{2})|Z)?)?)?
+              (?:[T\s]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?(?:[+-]\d{2}(?::\d{2})|Z)?)?)?
         )\z /x
 
   # The encoding used by all converters.

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -875,10 +875,9 @@ class CSV
   # A Regexp used to find and convert some common DateTime formats.
   DateTimeMatcher =
     / \A(?: (\w+,?\s+)?\w+\s+\d{1,2}\s+\d{1,2}:\d{1,2}:\d{1,2},?\s+\d{2,4} |
-            \d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2} |
-            # ISO-8601
+            # ISO-8601 and near-ISO (space instead of T) recognized by DateTime.parse
             \d{4}-\d{2}-\d{2}
-              (?:T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?(?:[+-]\d{2}(?::\d{2})|Z)?)?)?
+              (?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?(?:[+-]\d{2}(?::\d{2})|Z)?)?)?
         )\z /x
 
   # The encoding used by all converters.

--- a/test/csv/test_data_converters.rb
+++ b/test/csv/test_data_converters.rb
@@ -187,5 +187,4 @@ class TestCSVDataConverters < Test::Unit::TestCase
     assert_equal(datetime,
                  CSV::Converters[:date_time][rfc3339_string])
   end
-
 end

--- a/test/csv/test_data_converters.rb
+++ b/test/csv/test_data_converters.rb
@@ -104,18 +104,88 @@ class TestCSVDataConverters < Test::Unit::TestCase
                  CSV::Converters[:date_time][iso8601_string])
   end
 
-  def test_builtin_date_time_converter_near_iso
-    [ "2018-01-14 22:25",
-      "2018-01-14 22:25:19",
-      "2018-01-14 22:25:19.1",
-      "2018-01-14 22:25:19.1+09:00",
-      "2018-01-14 22:25:19+09:00",
-      "2018-01-14 22:25:19Z",
-    ].each do |string|
-      datetime = DateTime.parse(string)
-      assert_equal(datetime,
-                   CSV::Converters[:date_time][string])
-    end
+  def test_builtin_date_time_converter_rfc3339_minute
+    iso8601_string = "2018-01-14 22:25"
+    datetime = DateTime.new(2018, 1, 14, 22, 25)
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_second
+    iso8601_string = "2018-01-14 22:25:19"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19)
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_under_second
+    iso8601_string = "2018-01-14 22:25:19.1"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19.1)
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_under_second_offset
+    iso8601_string = "2018-01-14 22:25:19.1+09:00"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19.1, "+9")
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_offset
+    iso8601_string = "2018-01-14 22:25:19+09:00"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19, "+9")
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_utc
+    iso8601_string = "2018-01-14 22:25:19Z"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19)
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_tab_minute
+    iso8601_string = "2018-01-14\t22:25"
+    datetime = DateTime.new(2018, 1, 14, 22, 25)
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_tab_second
+    iso8601_string = "2018-01-14\t22:25:19"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19)
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_tab_under_second
+    iso8601_string = "2018-01-14\t22:25:19.1"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19.1)
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_tab_under_second_offset
+    iso8601_string = "2018-01-14\t22:25:19.1+09:00"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19.1, "+9")
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_tab_offset
+    iso8601_string = "2018-01-14\t22:25:19+09:00"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19, "+9")
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
+  end
+
+  def test_builtin_date_time_converter_rfc3339_tab_utc
+    iso8601_string = "2018-01-14\t22:25:19Z"
+    datetime = DateTime.new(2018, 1, 14, 22, 25, 19)
+    assert_equal(datetime,
+                 CSV::Converters[:date_time][iso8601_string])
   end
 
 end

--- a/test/csv/test_data_converters.rb
+++ b/test/csv/test_data_converters.rb
@@ -105,87 +105,87 @@ class TestCSVDataConverters < Test::Unit::TestCase
   end
 
   def test_builtin_date_time_converter_rfc3339_minute
-    iso8601_string = "2018-01-14 22:25"
+    rfc3339_string = "2018-01-14 22:25"
     datetime = DateTime.new(2018, 1, 14, 22, 25)
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_second
-    iso8601_string = "2018-01-14 22:25:19"
+    rfc3339_string = "2018-01-14 22:25:19"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19)
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_under_second
-    iso8601_string = "2018-01-14 22:25:19.1"
+    rfc3339_string = "2018-01-14 22:25:19.1"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19.1)
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_under_second_offset
-    iso8601_string = "2018-01-14 22:25:19.1+09:00"
+    rfc3339_string = "2018-01-14 22:25:19.1+09:00"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19.1, "+9")
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_offset
-    iso8601_string = "2018-01-14 22:25:19+09:00"
+    rfc3339_string = "2018-01-14 22:25:19+09:00"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19, "+9")
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_utc
-    iso8601_string = "2018-01-14 22:25:19Z"
+    rfc3339_string = "2018-01-14 22:25:19Z"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19)
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_tab_minute
-    iso8601_string = "2018-01-14\t22:25"
+    rfc3339_string = "2018-01-14\t22:25"
     datetime = DateTime.new(2018, 1, 14, 22, 25)
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_tab_second
-    iso8601_string = "2018-01-14\t22:25:19"
+    rfc3339_string = "2018-01-14\t22:25:19"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19)
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_tab_under_second
-    iso8601_string = "2018-01-14\t22:25:19.1"
+    rfc3339_string = "2018-01-14\t22:25:19.1"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19.1)
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_tab_under_second_offset
-    iso8601_string = "2018-01-14\t22:25:19.1+09:00"
+    rfc3339_string = "2018-01-14\t22:25:19.1+09:00"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19.1, "+9")
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_tab_offset
-    iso8601_string = "2018-01-14\t22:25:19+09:00"
+    rfc3339_string = "2018-01-14\t22:25:19+09:00"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19, "+9")
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
   def test_builtin_date_time_converter_rfc3339_tab_utc
-    iso8601_string = "2018-01-14\t22:25:19Z"
+    rfc3339_string = "2018-01-14\t22:25:19Z"
     datetime = DateTime.new(2018, 1, 14, 22, 25, 19)
     assert_equal(datetime,
-                 CSV::Converters[:date_time][iso8601_string])
+                 CSV::Converters[:date_time][rfc3339_string])
   end
 
 end

--- a/test/csv/test_data_converters.rb
+++ b/test/csv/test_data_converters.rb
@@ -103,4 +103,19 @@ class TestCSVDataConverters < Test::Unit::TestCase
     assert_equal(datetime,
                  CSV::Converters[:date_time][iso8601_string])
   end
+
+  def test_builtin_date_time_converter_near_iso
+    [ "2018-01-14 22:25",
+      "2018-01-14 22:25:19",
+      "2018-01-14 22:25:19.1",
+      "2018-01-14 22:25:19.1+09:00",
+      "2018-01-14 22:25:19+09:00",
+      "2018-01-14 22:25:19Z",
+    ].each do |string|
+      datetime = DateTime.parse(string)
+      assert_equal(datetime,
+                   CSV::Converters[:date_time][string])
+    end
+  end
+
 end


### PR DESCRIPTION
fix #247

ISO 8601 uses "T" for separator of date and time.
RFC 3339 also accepts a space for separator of date and time.