### PR TITLE
Readable prefix/suffix removal in Parser#strip_value

### DIFF
--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -1197,12 +1197,17 @@ class CSV
     end
 
     def strip_value(value)
-      return value if not @strip or value.nil?
+      return value unless @strip
+      return value if value.nil?
 
       case @strip
       when String
-        nil while value.delete_prefix!(@strip)
-        nil while value.delete_suffix!(@strip)
+        while value.delete_prefix!(@strip)
+          # do nothing
+        end
+        while value.delete_suffix!(@strip)
+          # do nothing
+        end
       else
         value.strip!
       end

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -1197,20 +1197,12 @@ class CSV
     end
 
     def strip_value(value)
-      return value unless @strip
-      return nil if value.nil?
+      return value if not @strip or value.nil?
 
       case @strip
       when String
-        size = value.size
-        while value.start_with?(@strip)
-          size -= 1
-          value = value[1, size]
-        end
-        while value.end_with?(@strip)
-          size -= 1
-          value = value[0, size]
-        end
+        nil while value.delete_prefix!(@strip)
+        nil while value.delete_suffix!(@strip)
       else
         value.strip!
       end


### PR DESCRIPTION
The use of ``String#delete_prefix!/delete_suffix!`` makes this method more readable.
It also makes possible to strip strings with more than one character.

Note that I am using the methods ending with ``!`` to modify ``value``, this matches the already used ``strip!``.
I also modified the early return to show that ``value`` is always returned, and with this PR all ``value`` modifications happen in-place.
This could be used to further simplify the method itself (no need to return a value) and the single usage I have found in ``Parser#parse_no_quote``: ``line = strip_value(line)`` to ``strip_value(line)``.

I have not done this modification yet to leave it open for discussion.