### PR TITLE
Add quoted information to CSV::FieldInfo #252

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -863,8 +863,9 @@ class CSV
   # <b><tt>index</tt></b>::  The zero-based index of the field in its row.
   # <b><tt>line</tt></b>::   The line of the data source this row is from.
   # <b><tt>header</tt></b>:: The header for the column, when available.
+  # <b><tt>quoted?</tt></b>:: True or false, whether the original value is quoted or not.
   #
-  FieldInfo = Struct.new(:index, :line, :header)
+  FieldInfo = Struct.new(:index, :line, :header, :quoted?)
 
   # A Regexp used to find and convert some common Date formats.
   DateMatcher     = / \A(?: (\w+,?\s+)?\w+\s+\d{1,2},?\s+\d{2,4} |

--- a/lib/csv/fields_converter.rb
+++ b/lib/csv/fields_converter.rb
@@ -44,7 +44,7 @@ class CSV
       @converters.empty?
     end
 
-    def convert(fields, headers, lineno)
+    def convert(fields, headers, lineno, quoted_fields)
       return fields unless need_convert?
 
       fields.collect.with_index do |field, index|
@@ -63,7 +63,8 @@ class CSV
             else
               header = nil
             end
-            field = converter[field, FieldInfo.new(index, lineno, header)]
+            quoted = quoted_fields[index]
+            field = converter[field, FieldInfo.new(index, lineno, header, quoted)]
           end
           break unless field.is_a?(String)  # short-circuit pipeline for speed
         end

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -770,7 +770,7 @@ class CSV
         @use_headers = true
       end
       if @raw_headers
-        @headers = adjust_headers(@raw_headers)
+        @headers = adjust_headers(@raw_headers, [])
       else
         @headers = nil
       end

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -783,8 +783,9 @@ class CSV
                      quote_char: @quote_character)
     end
 
-    def adjust_headers(headers)
-      adjusted_headers = @header_fields_converter.convert(headers, nil, @lineno)
+    def adjust_headers(headers, quoted_fields = nil)
+      quoted_fields = [] unless quoted_fields
+      adjusted_headers = @header_fields_converter.convert(headers, nil, @lineno, quoted_fields)
       adjusted_headers.each {|h| h.freeze if h.is_a? String}
       adjusted_headers
     end
@@ -928,9 +929,11 @@ class CSV
         if line.empty?
           next if @skip_blanks
           row = []
+          quoted_fields = []
         else
           line = strip_value(line)
           row = line.split(@split_column_separator, -1)
+          quoted_fields = []
           if @max_field_size
             row.each do |column|
               validate_field_size(column)
@@ -944,7 +947,7 @@ class CSV
           end
         end
         @last_line = original_line
-        emit_row(row, &block)
+        emit_row(row, quoted_fields, &block)
       end
     end
 
@@ -966,25 +969,30 @@ class CSV
             next
           end
           row = []
+          quoted_fields = []
         elsif line.include?(@cr) or line.include?(@lf)
           @scanner.keep_back
           @need_robust_parsing = true
           return parse_quotable_robust(&block)
         else
           row = line.split(@split_column_separator, -1)
+          quoted_fields = []
           n_columns = row.size
           i = 0
           while i < n_columns
             column = row[i]
             if column.empty?
+              quoted_fields << false
               row[i] = nil
             else
               n_quotes = column.count(@quote_character)
               if n_quotes.zero?
+                quoted_fields << false
                 # no quote
               elsif n_quotes == 2 and
                    column.start_with?(@quote_character) and
                    column.end_with?(@quote_character)
+                quoted_fields << true
                 row[i] = column[1..-2]
               else
                 @scanner.keep_back
@@ -999,13 +1007,14 @@ class CSV
         @scanner.keep_drop
         @scanner.keep_start
         @last_line = original_line
-        emit_row(row, &block)
+        emit_row(row, quoted_fields, &block)
       end
       @scanner.keep_drop
     end
 
     def parse_quotable_robust(&block)
       row = []
+      quoted_fields = []
       skip_needless_lines
       start_row
       while true
@@ -1021,18 +1030,19 @@ class CSV
           row << value
         elsif parse_row_end
           if row.empty? and value.nil?
-            emit_row([], &block) unless @skip_blanks
+            emit_row([], [], &block) unless @skip_blanks
           else
             row << value
-            emit_row(row, &block)
+            emit_row(row, quoted_fields, &block)
             row = []
+            quoted_fields = []
           end
           skip_needless_lines
           start_row
         elsif @scanner.eos?
           break if row.empty? and value.nil?
           row << value
-          emit_row(row, &block)
+          emit_row(row, quoted_fields, &block)
           break
         else
           if @quoted_column_value
@@ -1229,22 +1239,22 @@ class CSV
       @scanner.keep_start
     end
 
-    def emit_row(row, &block)
+    def emit_row(row, quoted_fields, &block)
       @lineno += 1
 
       raw_row = row
       if @use_headers
         if @headers.nil?
-          @headers = adjust_headers(row)
+          @headers = adjust_headers(row, quoted_fields)
           return unless @return_headers
           row = Row.new(@headers, row, true)
         else
           row = Row.new(@headers,
-                        @fields_converter.convert(raw_row, @headers, @lineno))
+                        @fields_converter.convert(raw_row, @headers, @lineno, quoted_fields))
         end
       else
         # convert fields, if needed...
-        row = @fields_converter.convert(raw_row, nil, @lineno)
+        row = @fields_converter.convert(raw_row, nil, @lineno, quoted_fields)
       end
 
       # inject unconverted fields and accessor, if requested...

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -783,7 +783,7 @@ class CSV
                      quote_char: @quote_character)
     end
 
-    def adjust_headers(headers, quoted_fields = nil)
+    def adjust_headers(headers, quoted_fields)
       quoted_fields = [] unless quoted_fields
       adjusted_headers = @header_fields_converter.convert(headers, nil, @lineno, quoted_fields)
       adjusted_headers.each {|h| h.freeze if h.is_a? String}
@@ -1028,11 +1028,13 @@ class CSV
         end
         if parse_column_end
           row << value
+          quoted_fields << @quoted_column_value
         elsif parse_row_end
           if row.empty? and value.nil?
             emit_row([], [], &block) unless @skip_blanks
           else
             row << value
+            quoted_fields << @quoted_column_value
             emit_row(row, quoted_fields, &block)
             row = []
             quoted_fields = []
@@ -1042,6 +1044,7 @@ class CSV
         elsif @scanner.eos?
           break if row.empty? and value.nil?
           row << value
+          quoted_fields << @quoted_column_value
           emit_row(row, quoted_fields, &block)
           break
         else

--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -39,7 +39,10 @@ class CSV
       @headers ||= row if @use_headers
       @lineno += 1
 
-      row = @fields_converter.convert(row, nil, lineno, []) if @fields_converter
+      if @fields_converter
+        quoted_fields = [false] * row.size
+        row = @fields_converter.convert(row, nil, lineno, quoted_fields)
+      end
 
       i = -1
       converted_row = row.collect do |field|

--- a/lib/csv/writer.rb
+++ b/lib/csv/writer.rb
@@ -39,7 +39,7 @@ class CSV
       @headers ||= row if @use_headers
       @lineno += 1
 
-      row = @fields_converter.convert(row, nil, lineno) if @fields_converter
+      row = @fields_converter.convert(row, nil, lineno, []) if @fields_converter
 
       i = -1
       converted_row = row.collect do |field|
@@ -94,7 +94,7 @@ class CSV
       return unless @headers
 
       converter = @options[:header_fields_converter]
-      @headers = converter.convert(@headers, nil, 0)
+      @headers = converter.convert(@headers, nil, 0, [])
       @headers.each do |header|
         header.freeze if header.is_a?(String)
       end

--- a/test/csv/parse/test_convert.rb
+++ b/test/csv/parse/test_convert.rb
@@ -119,12 +119,6 @@ class TestCSVParseConvert < Test::Unit::TestCase
           f
         end
       end
-
-      @csv = <<~CSV
-        "serial",value
-        "109",12
-        "10A",13
-      CSV
     end
 
     def test_parse_line
@@ -133,8 +127,12 @@ class TestCSVParseConvert < Test::Unit::TestCase
     end
 
     def test_parse
-      expected = [["serial", "value"], ["109", 12], ["10A", 13]]
-      rows = CSV.parse(@csv, converters: @preserving_converter)
+      expected = [["serial", "value"], ["109", 1], ["10A", 2]]
+      rows = CSV.parse(<<~CSV, converters: @preserving_converter)
+        "serial",value
+        "109",1
+        "10A",2
+      CSV
       assert_equal(expected, rows)
     end
 
@@ -144,8 +142,12 @@ class TestCSVParseConvert < Test::Unit::TestCase
         return f if info.quoted?
         f.to_sym
       end
-      expected = [["serial", :value], ["109", "12"], ["10A", "13"]]
-      table = CSV.parse(@csv, headers: true, header_converters: quoted_header_converter)
+      expected = [["serial", :value], ["109", "1"], ["10A", "2"]]
+      table = CSV.parse(<<~CSV, headers: true, header_converters: quoted_header_converter)
+        "serial",value
+        "109",1
+        "10A",2
+      CSV
       assert_equal(expected, table.to_a)
     end
   end

--- a/test/csv/parse/test_convert.rb
+++ b/test/csv/parse/test_convert.rb
@@ -107,4 +107,45 @@ class TestCSVParseConvert < Test::Unit::TestCase
     assert_equal([nil, "empty", "a"],
                  CSV.parse_line(',"",a', empty_value: "empty"))
   end
+
+  sub_test_case("add quoted info") do
+    def setup
+      @preserving_converter = lambda do |field, info|
+        f = field.encode(CSV::ConverterEncoding)
+        return field if info.quoted?
+        return DateTime.parse(f) if f.match?(DateTimeMatcher) rescue
+        return Integer(f) rescue
+        return Float(f) rescue
+        field
+      end
+
+      @str = <<~CSV
+        "serial",value
+        "109",12
+        "10A",13
+      CSV
+    end
+
+    def test_custom_field_info_quoted_parse_line
+      row = CSV.parse_line('1,"2",3', converters: @preserving_converter)
+      assert_equal([1, "2", 3], row)
+    end
+
+    def test_custom_field_info_quoted_parse
+      expected = [["serial", "value"], ["109", 12], ["10A", 13]]
+      row = CSV.parse(@str, converters: @preserving_converter)
+      assert_equal(expected, row)
+    end
+
+    def test_custom_field_info_quoted_parse_header
+      quoted_header_converter = lambda do |field, info|
+        f = field.encode(CSV::ConverterEncoding)
+        return field if info.quoted?
+        field.to_sym
+      end
+      expected = [["serial", :value], ["109", "12"], ["10A", "13"]]
+      row = CSV.parse(@str, headers: true, header_converters: quoted_header_converter)
+      assert_equal(expected, row.to_a)
+    end
+  end
 end

--- a/test/csv/parse/test_convert.rb
+++ b/test/csv/parse/test_convert.rb
@@ -113,7 +113,11 @@ class TestCSVParseConvert < Test::Unit::TestCase
       @preserving_converter = lambda do |field, info|
         f = field.encode(CSV::ConverterEncoding)
         return f if info.quoted?
-        Integer(f, 10)
+        begin
+          Integer(f, 10)
+        rescue
+          f
+        end
       end
 
       @csv = <<~CSV
@@ -130,7 +134,7 @@ class TestCSVParseConvert < Test::Unit::TestCase
 
     def test_parse
       expected = [["serial", "value"], ["109", 12], ["10A", 13]]
-      rows = CSV.parse(@str, converters: @preserving_converter)
+      rows = CSV.parse(@csv, converters: @preserving_converter)
       assert_equal(expected, rows)
     end
 
@@ -141,7 +145,7 @@ class TestCSVParseConvert < Test::Unit::TestCase
         f.to_sym
       end
       expected = [["serial", :value], ["109", "12"], ["10A", "13"]]
-      table = CSV.parse(@str, headers: true, header_converters: quoted_header_converter)
+      table = CSV.parse(@csv, headers: true, header_converters: quoted_header_converter)
       assert_equal(expected, table.to_a)
     end
   end

--- a/test/csv/parse/test_convert.rb
+++ b/test/csv/parse/test_convert.rb
@@ -150,5 +150,10 @@ class TestCSVParseConvert < Test::Unit::TestCase
       CSV
       assert_equal(expected, table.to_a)
     end
+
+    def test_alternating_quote
+      row = CSV.parse_line('"1",2,"3"', converters: @preserving_converter)
+      assert_equal(["1", 2, "3"], row)
+    end
   end
 end

--- a/test/csv/parse/test_convert.rb
+++ b/test/csv/parse/test_convert.rb
@@ -127,9 +127,9 @@ class TestCSVParseConvert < Test::Unit::TestCase
     end
 
     def test_parse
-      expected = [["serial", "value"], ["109", 1], ["10A", 2]]
+      expected = [["quoted", "unquoted"], ["109", 1], ["10A", 2]]
       rows = CSV.parse(<<~CSV, converters: @preserving_converter)
-        "serial",value
+        "quoted",unquoted
         "109",1
         "10A",2
       CSV
@@ -142,9 +142,9 @@ class TestCSVParseConvert < Test::Unit::TestCase
         return f if info.quoted?
         f.to_sym
       end
-      expected = [["serial", :value], ["109", "1"], ["10A", "2"]]
+      expected = [["quoted", :unquoted], ["109", "1"], ["10A", "2"]]
       table = CSV.parse(<<~CSV, headers: true, header_converters: quoted_header_converter)
-        "serial",value
+        "quoted",unquoted
         "109",1
         "10A",2
       CSV


### PR DESCRIPTION
This is a proposal to fix the issue #252;
- Add a new member `:quoted?` to `FieldInfo` .
- ~~Introduce an array of booleans `@quoted_fields` in Parser to collect original column value was quoted?.~~
- Check in each of `parse_no_quote`, `parse_quotable_loose` and `parse_quotable_robust`.
  - Use local variable `quoted_fields` to collect booleans in each method and pass it through `#emit_row`.
- Add test of custom converter for preserving quoted value.
