### PR TITLE
Correct the example for CSV.generate_lines

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1489,12 +1489,12 @@ class CSV
     # ---
     #
     # Returns the \String generated from an
-    #   CSV.generate_lines(['foo', '0'], ['bar', '1'], ['baz', '2']) # => "foo,0\nbar,1\nbaz.2\n"
+    #   CSV.generate_lines([['foo', '0'], ['bar', '1'], ['baz', '2']]) # => "foo,0\nbar,1\nbaz,2\n"
     #
     # ---
     #
     # Raises an exception
-    #   # Raises NoMethodError (undefined method `find' for :foo:Symbol)
+    #   # Raises NoMethodError (undefined method `each' for :foo:Symbol)
     #   CSV.generate_lines(:foo)
     #
     def generate_lines(rows, **options)


### PR DESCRIPTION
Correct the example for CSV.generate_lines

```ruby
3.0.0 :001'> CSV.generate_lines(['foo', '0'], ['bar', '1'], ['baz', '2'])
Traceback (most recent call last):
        3: from bin/console:14:in `<main>'
ArgumentError (wrong number of arguments (given 3, expected 1))
3.0.0 :002 > CSV.generate_lines([['foo', '0'], ['bar', '1'], ['baz', '2']])
 => "foo,0\nbar,1\nbaz,2\n" 
3.0.0 :003 > CSV.generate_lines(:foo)
Traceback (most recent call last):
        5: from bin/console:14:in `<main>'
        4: from (irb):12:in `<main>'
        3: from /csv/lib/csv.rb:1501:in `generate_lines'
        2: from /csv/lib/csv.rb:1409:in `generate'
        1: from /csv/lib/csv.rb:1502:in `block in generate_lines'
NoMethodError (undefined method `each' for :foo:Symbol)
```