### PR TITLE
docs: fix example in Recipe: Capture Unconverted Fields

### DIFF
--- a/doc/csv/recipes/parsing.rdoc
+++ b/doc/csv/recipes/parsing.rdoc
@@ -520,7 +520,7 @@ Apply multiple header converters by defining and registering a custom header con
 To capture unconverted field values, use option +:unconverted_fields+:
   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
   parsed = CSV.parse(source, converters: :integer, unconverted_fields: true)
-  parsed # => [["foo", "0"], ["bar", "1"], ["baz", "2"]]
+  parsed # => [["Name", "Value"], ["foo", 0], ["bar", 1], ["baz", 2]]
   parsed.each {|row| p row.unconverted_fields }
 Output:
   ["Name", "Value"]


### PR DESCRIPTION
I've fixed the example in `Recipe: Capture Unconverted Fields`.
https://ruby.github.io/csv/doc/csv/recipes/parsing_rdoc.html#label-Recipe-3A+Capture+Unconverted+Fields

`parsed` is wrong: header row is missing and the values should be integers.

```
$ ruby -v
ruby 3.2.1 (2023-02-08 revision 31819e82c8) [x86_64-darwin21]

$ cat unconverted_fields.rb
require "csv"

source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
parsed = CSV.parse(source, converters: :integer, unconverted_fields: true)
p parsed
parsed.each {|row| p row.unconverted_fields }

$ ruby unconverted_fields.rb
[["Name", "Value"], ["foo", 0], ["bar", 1], ["baz", 2]]
["Name", "Value"]
["foo", "0"]
["bar", "1"]
["baz", "2"]
```