### PR TITLE
test: rename Helper to CSVHelper

### DIFF
--- a/test/csv/helper.rb
+++ b/test/csv/helper.rb
@@ -5,7 +5,7 @@ require "csv"
 
 require_relative "../lib/with_different_ofs"
 
-module Helper
+module CSVHelper
   def with_chunk_size(chunk_size)
     chunk_size_keep = ENV["CSV_PARSER_SCANNER_TEST_CHUNK_SIZE"]
     begin

--- a/test/csv/parse/test_inputs_scanner.rb
+++ b/test/csv/parse/test_inputs_scanner.rb
@@ -1,7 +1,7 @@
 require_relative "../helper"
 
 class TestCSVParseInputsScanner < Test::Unit::TestCase
-  include Helper
+  include CSVHelper
 
   def test_scan_keep_over_chunks_nested_back
     input = CSV::Parser::UnoptimizedStringIO.new("abcdefghijklmnl")

--- a/test/csv/parse/test_row_separator.rb
+++ b/test/csv/parse/test_row_separator.rb
@@ -5,7 +5,7 @@ require_relative "../helper"
 
 class TestCSVParseRowSeparator < Test::Unit::TestCase
   extend DifferentOFS
-  include Helper
+  include CSVHelper
 
   def test_multiple_characters
     with_chunk_size("1") do

--- a/test/csv/parse/test_skip_lines.rb
+++ b/test/csv/parse/test_skip_lines.rb
@@ -4,7 +4,7 @@ require_relative "../helper"
 
 class TestCSVParseSkipLines < Test::Unit::TestCase
   extend DifferentOFS
-  include Helper
+  include CSVHelper
 
   def test_default
     csv = CSV.new("a,b,c\n")

--- a/test/csv/test_encodings.rb
+++ b/test/csv/test_encodings.rb
@@ -5,7 +5,7 @@ require_relative "helper"
 
 class TestCSVEncodings < Test::Unit::TestCase
   extend DifferentOFS
-  include Helper
+  include CSVHelper
 
   def setup
     super

--- a/test/csv/write/test_general.rb
+++ b/test/csv/write/test_general.rb
@@ -4,7 +4,7 @@
 require_relative "../helper"
 
 module TestCSVWriteGeneral
-  include Helper
+  include CSVHelper
 
   def test_tab
     assert_equal("\t#{$INPUT_RECORD_SEPARATOR}",


### PR DESCRIPTION
Rename it so that in ruby/ruby, the generic name Helper is not used.