### PR TITLE
Add CSV::InvalidEncodingError

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -854,6 +854,15 @@ class CSV
     end
   end
 
+  # The error thrown when the parser encounters invalid encoding in CSV.
+  class InvalidEncodingError < MalformedCSVError
+    attr_reader :encoding
+    def initialize(encoding, line_number)
+      @encoding = encoding
+      super("Invalid byte sequence in #{encoding}", line_number)
+    end
+  end
+
   #
   # A FieldInfo Struct contains details about a field's position in the data
   # source it was read from.  CSV will pass this Struct to some blocks that make

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -414,8 +414,7 @@ class CSV
         else
           lineno = @lineno + 1
         end
-        message = "Invalid byte sequence in #{@encoding}"
-        raise MalformedCSVError.new(message, lineno)
+        raise InvalidEncodingError.new(@encoding, lineno)
       rescue UnexpectedError => error
         if @scanner
           ignore_broken_line
@@ -876,8 +875,7 @@ class CSV
               !line.valid_encoding?
             end
             if index
-              message = "Invalid byte sequence in #{@encoding}"
-              raise MalformedCSVError.new(message, @lineno + index + 1)
+              raise InvalidEncodingError.new(@encoding, @lineno + index + 1)
             end
           end
           Scanner.new(string)

--- a/test/csv/interface/test_read.rb
+++ b/test/csv/interface/test_read.rb
@@ -113,11 +113,11 @@ class TestCSVInterfaceRead < Test::Unit::TestCase
       file << "\u{1F600},\u{1F601}"
     end
     CSV.open(@input.path, encoding: "EUC-JP") do |csv|
-      error = assert_raise(CSV::MalformedCSVError) do
+      error = assert_raise(CSV::InvalidEncodingError) do
         csv.shift
       end
-      assert_equal("Invalid byte sequence in EUC-JP in line 1.",
-                   error.message)
+      assert_equal([Encoding::EUC_JP, "Invalid byte sequence in EUC-JP in line 1."],
+                   [error.encoding, error.message])
     end
   end
 

--- a/test/csv/test_encodings.rb
+++ b/test/csv/test_encodings.rb
@@ -280,12 +280,12 @@ class TestCSVEncodings < Test::Unit::TestCase
   def test_invalid_encoding_row_error
     csv = CSV.new("valid,x\rinvalid,\xF8\r".force_encoding("UTF-8"),
                   encoding: "UTF-8", row_sep: "\r")
-    error = assert_raise(CSV::MalformedCSVError) do
+    error = assert_raise(CSV::InvalidEncodingError) do
       csv.shift
       csv.shift
     end
-    assert_equal("Invalid byte sequence in UTF-8 in line 2.",
-                 error.message)
+    assert_equal([Encoding::UTF_8, "Invalid byte sequence in UTF-8 in line 2."],
+                 [error.encoding, error.message])
   end
 
   def test_string_input_transcode


### PR DESCRIPTION
To handle encoding errors in CSV parsing with the appropriate error class