### PR TITLE
Use www.rfc-editor.org for RFC text.

### DIFF
--- a/doc/csv/recipes/generating.rdoc
+++ b/doc/csv/recipes/generating.rdoc
@@ -165,7 +165,7 @@ This example defines and uses two custom write converters to strip and upcase ge
 === RFC 4180 Compliance
 
 By default, \CSV generates data that is compliant with
-{RFC 4180}[https://tools.ietf.org/html/rfc4180]
+{RFC 4180}[https://www.rfc-editor.org/rfc/rfc4180]
 with respect to:
 - Column separator.
 - Quote character.

--- a/doc/csv/recipes/parsing.rdoc
+++ b/doc/csv/recipes/parsing.rdoc
@@ -191,7 +191,7 @@ Output:
 === RFC 4180 Compliance
 
 By default, \CSV parses data that is compliant with
-{RFC 4180}[https://tools.ietf.org/html/rfc4180]
+{RFC 4180}[https://www.rfc-editor.org/rfc/rfc4180]
 with respect to:
 - Row separator.
 - Column separator.


### PR DESCRIPTION
See details https://github.com/ruby/ruby/pull/10391

We should use `www.rfc-editor.org` for RFC references. I update docs in csv.