### PR TITLE
Fix typo in recipe "Parse from File with Headers"

### DIFF
--- a/doc/csv/recipes/parsing.rdoc
+++ b/doc/csv/recipes/parsing.rdoc
@@ -110,7 +110,7 @@ You can parse \CSV data from a \File, with or without headers.
 
 ===== Recipe: Parse from \File with Headers
 
-Use class method CSV#read with option +headers+ to read a file all at once:
+Use class method CSV.read with option +headers+ to read a file all at once:
   string = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
   path = 't.csv'
   File.write(path, string)

--- a/doc/csv/recipes/parsing.rdoc
+++ b/doc/csv/recipes/parsing.rdoc
@@ -110,7 +110,7 @@ You can parse \CSV data from a \File, with or without headers.
 
 ===== Recipe: Parse from \File with Headers
 
-Use instance method CSV#read with option +headers+ to read a file all at once:
+Use class method CSV#read with option +headers+ to read a file all at once:
   string = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
   path = 't.csv'
   File.write(path, string)


### PR DESCRIPTION
The text mentioned an instance method, the code itself uses a class method.