### PR TITLE
Add Time converter to CSV::Converters

### DIFF
--- a/doc/csv/recipes/parsing.rdoc
+++ b/doc/csv/recipes/parsing.rdoc
@@ -45,6 +45,7 @@ All code snippets on this page assume that the following has been executed:
     - {Recipe: Convert Fields to Numerics}[#label-Recipe-3A+Convert+Fields+to+Numerics]
     - {Recipe: Convert Fields to Dates}[#label-Recipe-3A+Convert+Fields+to+Dates]
     - {Recipe: Convert Fields to DateTimes}[#label-Recipe-3A+Convert+Fields+to+DateTimes]
+    - {Recipe: Convert Fields to Times}[#label-Recipe-3A+Convert+Fields+to+Times]
     - {Recipe: Convert Assorted Fields to Objects}[#label-Recipe-3A+Convert+Assorted+Fields+to+Objects]
     - {Recipe: Convert Fields to Other Objects}[#label-Recipe-3A+Convert+Fields+to+Other+Objects]
   - {Recipe: Filter Field Strings}[#label-Recipe-3A+Filter+Field+Strings]
@@ -339,6 +340,7 @@ There are built-in field converters for converting to objects of certain classes
 - \Integer
 - \Date
 - \DateTime
+- \Time
 
 Other built-in field converters include:
 - +:numeric+: converts to \Integer and \Float.
@@ -380,6 +382,13 @@ Convert fields to \DateTime objects using built-in converter +:date_time+:
   source = "Name,DateTime\nfoo,2001-02-03\nbar,2001-02-04\nbaz,2020-05-07T14:59:00-05:00\n"
   parsed = CSV.parse(source, headers: true, converters: :date_time)
   parsed.map {|row| row['DateTime'].class} # => [DateTime, DateTime, DateTime]
+
+===== Recipe: Convert Fields to Times
+
+Convert fields to \Time objects using built-in converter +:time+:
+  source = "Name,Time\nfoo,2001-02-03\nbar,2001-02-04\nbaz,2020-05-07T14:59:00-05:00\n"
+  parsed = CSV.parse(source, headers: true, converters: :time)
+  parsed.map {|row| row['Time'].class} # => [Time, Time, Time]
 
 ===== Recipe: Convert Assorted Fields to Objects
 

--- a/test/csv/test_data_converters.rb
+++ b/test/csv/test_data_converters.rb
@@ -187,4 +187,146 @@ class TestCSVDataConverters < Test::Unit::TestCase
     assert_equal(datetime,
                  CSV::Converters[:date_time][rfc3339_string])
   end
+
+  def test_builtin_time_converter
+    # does convert
+    assert_instance_of(Time,
+                       CSV::Converters[:time][@win_safe_time_str])
+
+    # does not convert
+    assert_instance_of(String, CSV::Converters[:time]["junk"])
+  end
+
+  def test_builtin_time_converter_iso8601_date
+    iso8601_string = "2018-01-14"
+    time = Time.new(2018, 1, 14)
+    assert_equal(time,
+                 CSV::Converters[:time][iso8601_string])
+  end
+
+  def test_builtin_time_converter_iso8601_minute
+    iso8601_string = "2018-01-14T22:25"
+    time = Time.new(2018, 1, 14, 22, 25)
+    assert_equal(time,
+                 CSV::Converters[:time][iso8601_string])
+  end
+
+  def test_builtin_time_converter_iso8601_second
+    iso8601_string = "2018-01-14T22:25:19"
+    time = Time.new(2018, 1, 14, 22, 25, 19)
+    assert_equal(time,
+                 CSV::Converters[:time][iso8601_string])
+  end
+
+  def test_builtin_time_converter_iso8601_under_second
+    iso8601_string = "2018-01-14T22:25:19.1"
+    time = Time.new(2018, 1, 14, 22, 25, 19.1r)
+    assert_equal(time,
+                 CSV::Converters[:time][iso8601_string])
+  end
+
+  def test_builtin_time_converter_iso8601_under_second_offset
+    iso8601_string = "2018-01-14T22:25:19.1+09:00"
+    time = Time.new(2018, 1, 14, 22, 25, 19.1r, "+09:00")
+    assert_equal(time,
+                 CSV::Converters[:time][iso8601_string])
+  end
+
+  def test_builtin_time_converter_iso8601_offset
+    iso8601_string = "2018-01-14T22:25:19+09:00"
+    time = Time.new(2018, 1, 14, 22, 25, 19, "+09:00")
+    assert_equal(time,
+                 CSV::Converters[:time][iso8601_string])
+  end
+
+  def test_builtin_time_converter_iso8601_utc
+    iso8601_string = "2018-01-14T22:25:19Z"
+    time = Time.utc(2018, 1, 14, 22, 25, 19)
+    assert_equal(time,
+                 CSV::Converters[:time][iso8601_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_minute
+    rfc3339_string = "2018-01-14 22:25"
+    time = Time.new(2018, 1, 14, 22, 25)
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_second
+    rfc3339_string = "2018-01-14 22:25:19"
+    time = Time.new(2018, 1, 14, 22, 25, 19)
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_under_second
+    rfc3339_string = "2018-01-14 22:25:19.1"
+    time = Time.new(2018, 1, 14, 22, 25, 19.1r)
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_under_second_offset
+    rfc3339_string = "2018-01-14 22:25:19.1+09:00"
+    time = Time.new(2018, 1, 14, 22, 25, 19.1r, "+09:00")
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_offset
+    rfc3339_string = "2018-01-14 22:25:19+09:00"
+    time = Time.new(2018, 1, 14, 22, 25, 19, "+09:00")
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_utc
+    rfc3339_string = "2018-01-14 22:25:19Z"
+    time = Time.utc(2018, 1, 14, 22, 25, 19)
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_tab_minute
+    rfc3339_string = "2018-01-14\t22:25"
+    time = Time.new(2018, 1, 14, 22, 25)
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_tab_second
+    rfc3339_string = "2018-01-14\t22:25:19"
+    time = Time.new(2018, 1, 14, 22, 25, 19)
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_tab_under_second
+    rfc3339_string = "2018-01-14\t22:25:19.1"
+    time = Time.new(2018, 1, 14, 22, 25, 19.1r)
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_tab_under_second_offset
+    rfc3339_string = "2018-01-14\t22:25:19.1+09:00"
+    time = Time.new(2018, 1, 14, 22, 25, 19.1r, "+09:00")
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_tab_offset
+    rfc3339_string = "2018-01-14\t22:25:19+09:00"
+    time = Time.new(2018, 1, 14, 22, 25, 19, "+09:00")
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
+
+  def test_builtin_time_converter_rfc3339_tab_utc
+    rfc3339_string = "2018-01-14\t22:25:19Z"
+    time = Time.utc(2018, 1, 14, 22, 25, 19)
+    assert_equal(time,
+                 CSV::Converters[:time][rfc3339_string])
+  end
 end


### PR DESCRIPTION
Ruby recommends working with Time objects, unless you have a good reason to use DateTime: https://ruby-doc.org/stdlib-2.5.0/libdoc/date/rdoc/DateTime.html#class-DateTime-label-When+should+you+use+DateTime+and+when+should+you+use+Time-3F

This commit adds the missing converter for the common modern use case.