### PR TITLE
Add :sep as an alias for :col_sep

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -2033,6 +2033,7 @@ class CSV
   #
   def initialize(data,
                  col_sep: ",",
+                 sep: nil,
                  row_sep: :auto,
                  quote_char: '"',
                  field_size_limit: nil,
@@ -2058,6 +2059,11 @@ class CSV
                  write_nil_value: nil,
                  write_empty_value: "")
     raise ArgumentError.new("Cannot parse nil as CSV") if data.nil?
+
+    if sep && col_sep != ","
+      raise ArgumentError, "Cannot specify both :sep and :col_sep"
+    end
+    actual_sep = sep || col_sep
 
     if data.is_a?(String)
       if encoding
@@ -2094,7 +2100,7 @@ class CSV
       max_field_size = field_size_limit - 1
     end
     @parser_options = {
-      column_separator: col_sep,
+      column_separator: actual_sep,
       row_separator: row_sep,
       quote_character: quote_char,
       max_field_size: max_field_size,


### PR DESCRIPTION
This PR adds :sep as a shorter alias for :col_sep to improve usability:

- Adds :sep option that acts as alias for :col_sep
- Reduces keystrokes (3 vs 8) when specifying separator
- Aligns with other data libraries like pandas (pd.read_csv(sep="\t"))
- Maintains backward compatibility
- Raises clear error if both options specified

---
Example usage:
```ruby
# Old way
CSV.read("data.tsv", col_sep: "\t")

# New way
CSV.read("data.tsv", sep: "\t")
```

---


The change is motivated by:

1. Making the interface more ergonomic with shorter option name
2. Better alignment with common practices in other data libraries

---
Changes:

1. Adds sep parameter to CSV#initialize
2. Adds error check for both options
3. Uses sep value if provided, otherwise falls back to col_sep

---
Inspired by https://github.com/ruby/csv/issues/272
