### PR TITLE
Add TSV class for tab-separated values

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -2129,6 +2129,92 @@ class CSV
     writer if @writer_options[:write_headers]
   end
 
+  class TSV < CSV
+    def initialize(data, **options)
+      options = options.dup
+      if !options.key?(:col_sep) && !options.key?(:sep)
+        options[:col_sep] = "\t"
+      end
+      super(data, **options)
+    end
+
+    class << self
+      def foreach(path, mode="r", **options, &block)
+        options = options.dup
+        if !options.key?(:col_sep) && !options.key?(:sep)
+          options[:col_sep] = "\t"
+        end
+        CSV.foreach(path, mode, **options, &block)
+      end
+
+      def read(path, **options)
+        options = options.dup
+        if !options.key?(:col_sep) && !options.key?(:sep)
+          options[:col_sep] = "\t"
+        end
+        CSV.read(path, **options)
+      end
+
+      def parse(str, **options)
+        options = options.dup
+        if !options.key?(:col_sep) && !options.key?(:sep)
+          options[:col_sep] = "\t"
+        end
+        CSV.parse(str, **options)
+      end
+
+      def generate(str = nil, **options)
+        options = with_default_separator(options)
+        CSV.generate(str, **options)
+      end
+
+      def open(filename, mode="rb", **options, &block)
+        options = with_default_separator(options)
+        CSV.open(filename, mode, **options, &block)
+      end
+
+      def table(path, **options)
+        options = with_default_separator(options)
+        CSV.table(path, **options)
+      end
+
+      def parse_line(line, **options)
+        options = with_default_separator(options)
+        CSV.parse_line(line, **options)
+      end
+
+      def generate_line(row, **options)
+        options = with_default_separator(options)
+        CSV.generate_line(row, **options)
+      end
+
+      def instance(data = nil, **options, &block)
+        options = with_default_separator(options)
+        CSV.instance(data, **options, &block)
+      end
+
+      def filter(input=nil, output=nil, **options, &block)
+        options = with_default_separator(options)
+        CSV.filter(input, output, **options, &block)
+      end
+
+      def readlines(path, **options)
+        options = with_default_separator(options)
+        CSV.readlines(path, **options)
+      end
+
+      private
+
+      def with_default_separator(options)
+        options = options.dup
+        if !options.key?(:col_sep) && !options.key?(:sep)
+          options[:col_sep] = "\t"
+        end
+        options
+      end
+    end
+  end
+
   # :call-seq:
   #   csv.col_sep -> string
   #


### PR DESCRIPTION
This PR adds a new TSV class to provide first-class support for tab-separated files:

1. Inherits from CSV class
2. Uses tab as default separator
3. Full interface parity with CSV
4. All class methods supported (parse, read, generate etc.)
5. Allows override of default separator if needed

---
Example usage:

```
# Use TSV class with default tab separator
TSV.read("data.tsv")
TSV.parse("a\tb\tc")

# Override separator if needed
TSV.read("data.csv", col_sep: ",")
```

---
The change is motivated by:

1. Providing better support for TSV files
2. Making tab-separated file handling more convenient

---
Inspired by https://github.com/ruby/csv/issues/272