### PR TITLE
Drop `:nodoc:` options from core classes that contains methods with docs

### DIFF
--- a/lib/csv/core_ext/array.rb
+++ b/lib/csv/core_ext/array.rb
@@ -1,4 +1,4 @@
-class Array # :nodoc:
+class Array
   # Equivalent to CSV::generate_line(self, options)
   #
   #   ["CSV", "data"].to_csv

--- a/lib/csv/core_ext/string.rb
+++ b/lib/csv/core_ext/string.rb
@@ -1,4 +1,4 @@
-class String # :nodoc:
+class String
   # Equivalent to CSV::parse_line(self, options)
   #
   #   "CSV,data".parse_csv


### PR DESCRIPTION
I found some methods are not included in RDoc output, and the `:nodoc:` option should be the reason.

It seems like there is no reason to opt-out the methods. https://github.com/ruby/csv/commit/7b79bec2779c53245cabe396ef36a13e8ab50338 added the option, but still not clear why we needed it.