### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/csv

### DIFF
--- a/csv.gemspec
+++ b/csv.gemspec
@@ -55,4 +55,6 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = rdoc_files
 
   spec.required_ruby_version = ">= 2.5.0"
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
 end

--- a/csv.gemspec
+++ b/csv.gemspec
@@ -56,5 +56,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/releases/tag/v#{spec.version}"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/csv which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata