### PR TITLE
Use `Ractor#value` as `Ractor#take` is removed

### DIFF
--- a/test/csv/helper.rb
+++ b/test/csv/helper.rb
@@ -40,3 +40,7 @@ module CSVHelper
     end
   end
 end
+
+class Ractor
+  alias value take unless method_defined? :value
+end if defined?(Ractor)

--- a/test/csv/interface/test_read.rb
+++ b/test/csv/interface/test_read.rb
@@ -64,7 +64,7 @@ class TestCSVInterfaceRead < Test::Unit::TestCase
         ["1", "2", "3"],
         ["4", "5"],
       ]
-      assert_equal(rows, ractor.take)
+      assert_equal(rows, ractor.value)
     end
   end
 
@@ -315,7 +315,7 @@ class TestCSVInterfaceRead < Test::Unit::TestCase
         ["1", "2", "3"],
         ["4", "5"],
       ]
-      assert_equal(rows, ractor.take)
+      assert_equal(rows, ractor.value)
     end
   end
 

--- a/test/csv/interface/test_write.rb
+++ b/test/csv/interface/test_write.rb
@@ -33,7 +33,7 @@ class TestCSVInterfaceWrite < Test::Unit::TestCase
           csv << [1, 2, 3] << [4, nil, 5]
         end
       end
-      assert_equal(<<-CSV, ractor.take)
+      assert_equal(<<-CSV, ractor.value)
 1,2,3
 4,,5
       CSV
@@ -125,7 +125,6 @@ a,b,c
     CSV
   end
 
-
   if respond_to?(:ractor)
     ractor
     def test_append_row_in_ractor
@@ -136,7 +135,7 @@ a,b,c
             CSV::Row.new([], ["a", "b", "c"])
         end
       end
-      ractor.take
+      ractor.value
       assert_equal(<<-CSV, File.read(@output.path, mode: "rb"))
 1,2,3
 a,b,c


### PR DESCRIPTION
To keep compatibility with older Rubys, left alias value take.

See https://bugs.ruby-lang.org/issues/21262
