### PR TITLE
ci: don't use Ruby 2.5 on Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
           - windows-latest
         exclude:
           - { runs-on: macos-latest, ruby-version: "2.5" }
+          # Can't mix newer Psych and old RubyGems/Bundler
+          - { runs-on: ubuntu-latest, ruby-version: "2.5" }
           - { runs-on: windows-latest, ruby-version: "3.1" }
           - { runs-on: windows-latest, ruby-version: debug }
         include:
@@ -55,6 +57,8 @@ jobs:
           - windows-latest
         exclude:
           - { runs-on: macos-latest, ruby-version: "2.5" }
+          # Can't mix newer Psych and old RubyGems/Bundler
+          - { runs-on: ubuntu-latest, ruby-version: "2.5" }
           - { runs-on: windows-latest, ruby-version: "3.1" }
           - { runs-on: windows-latest, ruby-version: debug }
         include:


### PR DESCRIPTION
We can't mix newer Psych and old RubyGems/Bundler.

https://github.com/ruby/csv/actions/runs/15464303477/job/43532710831?pr=346#step:3:47

    Failed to load /home/runner/.gemrc, wrong number of arguments (given 2, expected 1)
    Fetching gem metadata from https://rubygems.org/........
    Fetching rake 13.3.0
    --- ERROR REPORT TEMPLATE -------------------------------------------------------

    ```
    ArgumentError: wrong number of arguments (given 4, expected 1)
      /home/runner/work/csv/csv/vendor/bundle/ruby/2.5.0/gems/psych-5.2.6/lib/psych.rb:323:in `safe_load'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/safe_yaml.rb:31:in `safe_load'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:496:in `block (2 levels) in read_checksums'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:495:in `wrap'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:495:in `block in read_checksums'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package/tar_reader.rb:116:in `seek'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:494:in `read_checksums'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:547:in `block (2 levels) in verify'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package/tar_reader.rb:29:in `new'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:546:in `block in verify'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package/file_source.rb:30:in `open'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package/file_source.rb:30:in `with_read_io'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:545:in `verify'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:526:in `spec'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/rubygems_gem_installer.rb:95:in `spec'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/source/rubygems.rb:190:in `install'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer/gem_installer.rb:54:in `install'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer/parallel_installer.rb:90:in `call'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer/parallel_installer.rb:71:in `call'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer.rb:254:in `install_in_parallel'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer.rb:209:in `install'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer.rb:89:in `block in run'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/process_lock.rb:12:in `block in lock'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/process_lock.rb:9:in `open'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/process_lock.rb:9:in `lock'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer.rb:71:in `run'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/installer.rb:23:in `install'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/cli/install.rb:62:in `run'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/cli.rb:257:in `block in install'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/settings.rb:131:in `temporary'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/cli.rb:256:in `install'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/cli.rb:31:in `dispatch'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/cli.rb:25:in `start'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/exe/bundle:48:in `block in <top (required)>'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.27/exe/bundle:36:in `<top (required)>'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/bin/bundle:23:in `load'
      /opt/hostedtoolcache/Ruby/2.5.9/x64/bin/bundle:23:in `<main>'