### PR TITLE
ci benchmark: ensure installing old versions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -24,8 +24,9 @@ jobs:
       - name: Install dependencies
         run: |
           bundle install
-          gem install csv -v 3.0.1
-          gem install csv -v 3.0.2
+      - name: Install old versions
+        run: |
+          rake benchmark:old_versions:install
       - name: Benchmark
         run: |
           rake benchmark

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,10 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem "benchmark_driver"
   gem "bundler"
+  gem "psych"
   gem "rake"
   gem "rdoc"
-  gem "benchmark_driver"
   gem "test-unit", ">= 3.4.8"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "rbconfig"
 require "rdoc/task"
+require "yaml"
 
 require "bundler/gem_tasks"
 
@@ -59,6 +60,22 @@ namespace :benchmark do
           puts("```")
         end
         benchmark_tasks << "benchmark:#{name}:small"
+      end
+    end
+  end
+
+  namespace :old_versions do
+    desc "Install used old versions"
+    task :install do
+      old_versions = []
+      Dir.glob("benchmark/*.yaml") do |yaml|
+        YAML.load_file(yaml)["contexts"].each do |context|
+          old_version = (context["gems"] || {})["csv"]
+          old_versions << old_version if old_version
+        end
+      end
+      old_versions.uniq.sort.each do |old_version|
+        ruby("-S", "gem", "install", "csv", "-v", old_version)
       end
     end
   end


### PR DESCRIPTION
Benchmark CI is failing because csv 3.3.0 isn't installed:

https://github.com/ruby/csv/actions/runs/15481241182/job/43587350229#step:5:10

```text
/opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/3.4.0/rubygems/dependency.rb:303:in 'Gem::Dependency#to_specs': Could not find 'csv' (= 3.3.0) - did find: [csv-3.3.2,csv-3.0.2,csv-3.0.1] (Gem::MissingSpecVersionError)
```