### PR TITLE
Fix typo in documentation: use `lineno` instead of `line_no`

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -2327,7 +2327,7 @@ class CSV
   attr_reader :encoding
 
   # :call-seq:
-  #   csv.line_no -> integer
+  #   csv.lineno -> integer
   #
   # Returns the count of the rows parsed or generated.
   #


### PR DESCRIPTION
Found a typo in the documentation where it says `csv.line_no`.  
The correct method is `csv.lineno`.  

This PR fixes it.
