### PR TITLE
Fix frozen string literal warning

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1456,7 +1456,7 @@ class CSV
       encoding = options[:encoding]
       # add a default empty String, if none was given
       if str
-        str = StringIO.new(str)
+        str = StringIO.new(+str)
         str.seek(0, IO::SEEK_END)
         str.set_encoding(encoding) if encoding
       else


### PR DESCRIPTION
This PR fixes the frozen string literal warning

```
/.asdf/installs/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/csv-3.3.0/lib/csv/writer.rb:56: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```