### PR TITLE
Support block in CSV::Row#to_h

### DIFF
--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -652,7 +652,8 @@ class CSV
     #   row.to_h # => {"Name"=>"Foo"}
     def to_h
       hash = {}
-      each do |key, value|
+      each do |key, _value|
+        value = self[key]
         key, value = yield(key, value) if block_given?
 
         hash[key] = value unless hash.key?(key)

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -653,12 +653,9 @@ class CSV
     def to_h
       hash = {}
       each do |key, value|
-        new_key, new_value = if block_given?
-          yield(key, value)
-        else
-          [key, value]
-        end
-        hash[new_key] = new_value unless hash.key?(new_key)
+        key, value = yield(key, value) if block_given?
+
+        hash[key] = value unless hash.key?(key)
       end
       hash
     end

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -637,6 +637,7 @@ class CSV
 
     # :call-seq:
     #   row.to_h -> hash
+    #   row.to_h {|key, value| ... } -> hash
     #
     # Returns the new \Hash formed by adding each header-value pair in +self+
     # as a key-value pair in the \Hash.

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -650,13 +650,21 @@ class CSV
     #   table = CSV.parse(source, headers: true)
     #   row = table[0]
     #   row.to_h # => {"Name"=>"Foo"}
+    #
+    # If a block is given, will call it with (key, value) arguments and use result as a hash entry:
+    #   source = "Name,Value\nfoo,1\nbar,2\nbaz,3\n"
+    #   table = CSV.parse(source, headers: true)
+    #   row = table[0]
+    #   row.to_h { |key, value| [key, value.to_i * 2] } # => {"Name"=>"foo", "Value"=>2}
     def to_h
       hash = {}
       each do |key, _value|
+        next if hash.key?(key)
+
         value = self[key]
         key, value = yield(key, value) if block_given?
 
-        hash[key] = value unless hash.key?(key)
+        hash[key] = value
       end
       hash
     end

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -652,8 +652,13 @@ class CSV
     #   row.to_h # => {"Name"=>"Foo"}
     def to_h
       hash = {}
-      each do |key, _value|
-        hash[key] = self[key] unless hash.key?(key)
+      each do |key, value|
+        new_key, new_value = if block_given?
+          yield(key, value)
+        else
+          [key, value]
+        end
+        hash[new_key] = new_value unless hash.key?(new_key)
       end
       hash
     end

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -662,11 +662,12 @@ class CSV
 
       if block_given?
         each do |key, _value|
-          result = yield(key, self[key])
-          raise TypeError, "wrong element type #{result.class} (expected array)" unless result.is_a?(Array)
+          result = Array.try_convert(yield(key, self[key]))
+          raise TypeError, "wrong element type #{result.class} (expected array)" if result.nil?
           raise ArgumentError, "wrong array length (expected 2, was #{result.size})" unless result.size == 2
 
           key, value = result
+          key.freeze if key.is_a?(String) && !key.frozen?
           hash[key] = value unless hash.key?(key)
         end
       else

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -656,18 +656,19 @@ class CSV
     #   source = "Name,Value\nfoo,1\nbar,2\nbaz,3\n"
     #   table = CSV.parse(source, headers: true)
     #   row = table[0]
-    #   row.to_h { |key, value| [key, value.to_i * 2] } # => {"Name"=>"foo", "Value"=>2}
+    #   row.to_h { |key, value| [key, "#{key}-#{value}"] } # => {"Name"=>"Name-foo", "Value"=>"Value-1"}
     def to_h
       hash = {}
 
       if block_given?
         each do |key, _value|
-          result = Array.try_convert(yield(key, self[key]))
-          raise TypeError, "wrong element type #{result.class} (expected array)" if result.nil?
-          raise ArgumentError, "wrong array length (expected 2, was #{result.size})" unless result.size == 2
+          result = yield(key, self[key])
+          result_array = Array.try_convert(result)
+          raise TypeError, "wrong element type #{result.class} (expected array)" if result_array.nil?
+          raise ArgumentError, "wrong array length (expected 2, was #{result_array.size})" unless result_array.size == 2
 
-          key, value = result
-          key.freeze if key.is_a?(String) && !key.frozen?
+          key, value = result_array
+          key.freeze if key.is_a?(String)
           hash[key] = value unless hash.key?(key)
         end
       else

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -668,8 +668,10 @@ class CSV
           raise ArgumentError, "wrong array length (expected 2, was #{result_array.size})" unless result_array.size == 2
 
           key, value = result_array
-          key.freeze if key.is_a?(String)
-          hash[key] = value unless hash.key?(key)
+          next if hash.key?(key)
+
+          key.freeze if key.is_a?(String) && !key.frozen?
+          hash[key] = value
         end
       else
         each do |key, _value|

--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -659,14 +659,22 @@ class CSV
     #   row.to_h { |key, value| [key, value.to_i * 2] } # => {"Name"=>"foo", "Value"=>2}
     def to_h
       hash = {}
-      each do |key, _value|
-        next if hash.key?(key)
 
-        value = self[key]
-        key, value = yield(key, value) if block_given?
+      if block_given?
+        each do |key, _value|
+          result = yield(key, self[key])
+          raise TypeError, "wrong element type #{result.class} (expected array)" unless result.is_a?(Array)
+          raise ArgumentError, "wrong array length (expected 2, was #{result.size})" unless result.size == 2
 
-        hash[key] = value
+          key, value = result
+          hash[key] = value unless hash.key?(key)
+        end
+      else
+        each do |key, _value|
+          hash[key] = self[key] unless hash.key?(key)
+        end
       end
+
       hash
     end
     alias_method :to_hash, :to_h

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -341,27 +341,26 @@ class TestCSVRow < Test::Unit::TestCase
     end
   end
 
-  def test_to_hash_with_block
-    row = CSV::Row.new(%w{A A B C}, [1, 2, 2, 3])
-    hash1 = row.to_hash { |k, v| [k, v**2] }
-    assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash1)
-    hash1.each_key do |string_key|
+  def test_to_hash_with_block_transform_values
+    hash = @row.to_hash { |k, v| [k, v**2] }
+    assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash)
+    hash.each_key do |string_key|
       assert_predicate(string_key, :frozen?)
     end
-
-    new_keys_map = {"A" => "A", "B" => "B", "C" => "B"}
-    hash2 = row.to_hash { |k, v| [new_keys_map[k], v**2] }
-    assert_equal({"A" => 1, "B" => 4}, hash2)
-    hash2.each_key do |string_key|
-      assert_predicate(string_key, :frozen?)
-    end
-
     assert_raise TypeError do
-      row.to_hash { "foo" }
+      @row.to_hash { "foo" }
     end
-
     assert_raise ArgumentError do
-      row.to_hash { [1] }
+      @row.to_hash { [1] }
+    end
+  end
+
+  def test_to_hash_with_block_transform_entries
+    new_keys_map = {"A" => "A", "B" => "B", "C" => "B"}
+    hash = @row.to_hash { |k, v| [new_keys_map[k], v**2] }
+    assert_equal({"A" => 1, "B" => 4}, hash)
+    hash.each_key do |string_key|
+      assert_predicate(string_key, :frozen?)
     end
   end
 

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -342,8 +342,8 @@ class TestCSVRow < Test::Unit::TestCase
   end
 
   def test_to_hash_with_block
-    row =  CSV::Row.new(%w{A B C}, [1, 2, 3])
-    hash = row.to_hash { |k, v| [k, v ** 2] }
+    row =  CSV::Row.new(%w{A A B C}, [1, 2, 2, 3])
+    hash = row.to_hash { |k, v| [k, v**2] }
     assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash)
   end
 

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -339,9 +339,12 @@ class TestCSVRow < Test::Unit::TestCase
       assert_predicate(string_key, :frozen?)
       assert_same(string_key, @row.headers[h])
     end
-    row2 =  CSV::Row.new(%w{A B C}, [1, 2, 3])
-    hash2 = row2.to_hash { |k, v| [k, v ** 2] }
-    assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash2)
+  end
+
+  def test_to_hash_with_block
+    row =  CSV::Row.new(%w{A B C}, [1, 2, 3])
+    hash = row.to_hash { |k, v| [k, v ** 2] }
+    assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash)
   end
 
   def test_to_csv

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -342,7 +342,7 @@ class TestCSVRow < Test::Unit::TestCase
   end
 
   def test_to_hash_with_block
-    row =  CSV::Row.new(%w{A B C}, [1, 2, 3])
+    row = CSV::Row.new(%w{A B C}, [1, 2, 3])
     hash = row.to_hash { |k, v| [k, v ** 2] }
     assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash)
   end

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -346,7 +346,7 @@ class TestCSVRow < Test::Unit::TestCase
     new_keys_map = {"A" => "A", "B" => "B", "C" => "B"}
     hash = row.to_hash { |k, v| [new_keys_map[k], v**2] }
     assert_equal({"A" => 1, "B" => 4}, hash)
-    hash.keys.each_with_index do |string_key, h|
+    hash.each_key do |string_key|
       assert_predicate(string_key, :frozen?)
     end
 

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -343,8 +343,20 @@ class TestCSVRow < Test::Unit::TestCase
 
   def test_to_hash_with_block
     row = CSV::Row.new(%w{A A B C}, [1, 2, 2, 3])
-    hash = row.to_hash { |k, v| [k, v**2] }
-    assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash)
+    new_keys_map = {"A" => "A", "B" => "B", "C" => "B"}
+    hash = row.to_hash { |k, v| [new_keys_map[k], v**2] }
+    assert_equal({"A" => 1, "B" => 4}, hash)
+    hash.keys.each_with_index do |string_key, h|
+      assert_predicate(string_key, :frozen?)
+    end
+
+    assert_raise TypeError do
+      row.to_hash { "foo" }
+    end
+
+    assert_raise ArgumentError do
+      row.to_hash { [1] }
+    end
   end
 
   def test_to_csv

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -339,6 +339,9 @@ class TestCSVRow < Test::Unit::TestCase
       assert_predicate(string_key, :frozen?)
       assert_same(string_key, @row.headers[h])
     end
+    row2 =  CSV::Row.new(%w{A B C}, [1, 2, 3])
+    hash2 = row2.to_hash { |k, v| [k, v ** 2] }
+    assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash2)
   end
 
   def test_to_csv

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -343,10 +343,16 @@ class TestCSVRow < Test::Unit::TestCase
 
   def test_to_hash_with_block
     row = CSV::Row.new(%w{A A B C}, [1, 2, 2, 3])
+    hash1 = row.to_hash { |k, v| [k, v**2] }
+    assert_equal({"A" => 1, "B" => 4, "C" => 9}, hash1)
+    hash1.each_key do |string_key|
+      assert_predicate(string_key, :frozen?)
+    end
+
     new_keys_map = {"A" => "A", "B" => "B", "C" => "B"}
-    hash = row.to_hash { |k, v| [new_keys_map[k], v**2] }
-    assert_equal({"A" => 1, "B" => 4}, hash)
-    hash.each_key do |string_key|
+    hash2 = row.to_hash { |k, v| [new_keys_map[k], v**2] }
+    assert_equal({"A" => 1, "B" => 4}, hash2)
+    hash2.each_key do |string_key|
       assert_predicate(string_key, :frozen?)
     end
 


### PR DESCRIPTION
It will be consistent with Ruby's method, otherwise it has to be like `row.entries.to_h { ... }`