### PR TITLE
Unify first parameter name to `path_or_io` across methods

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1377,7 +1377,7 @@ class CSV
     # * Arguments <tt>**options</tt> must be keyword options.
     #   See {Options for Parsing}[#class-CSV-label-Options+for+Parsing].
     # * This method optionally accepts an additional <tt>:encoding</tt> option
-    #   that you can use to specify the Encoding of the data read from +path+ or +io+.
+    #   that you can use to specify the Encoding of the data read from +path_or_io+.
     #   You must provide this unless your data is in the encoding
     #   given by <tt>Encoding::default_external</tt>.
     #   Parsing will use this to determine how to parse the data.

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1302,10 +1302,10 @@ class CSV
 
     #
     # :call-seq:
-    #   foreach(path_or_io, mode='r', **options) {|row| ... )
-    #   foreach(path_or_io, mode='r', **options) -> new_enumerator
+    #   foreach(filename_or_io, mode='r', **options) {|row| ... )
+    #   foreach(filename_or_io, mode='r', **options) -> new_enumerator
     #
-    # Calls the block with each row read from source +path_or_io+.
+    # Calls the block with each row read from source +filename_or_io+.
     #
     # \Path input without headers:
     #
@@ -1371,7 +1371,7 @@ class CSV
     #   CSV.foreach(path) # => #<Enumerator: CSV:foreach("t.csv", "r")>
     #
     # Arguments:
-    # * Argument +path_or_io+ must be a file path or an \IO stream.
+    # * Argument +filename_or_io+ must be a file path or an \IO stream.
     # * Argument +mode+, if given, must be a \File mode.
     #   See {Access Modes}[https://docs.ruby-lang.org/en/master/File.html#class-File-label-Access+Modes].
     # * Arguments <tt>**options</tt> must be keyword options.
@@ -1386,9 +1386,9 @@ class CSV
     #     encoding: 'UTF-32BE:UTF-8'
     #   would read +UTF-32BE+ data from the file
     #   but transcode it to +UTF-8+ before parsing.
-    def foreach(path, mode="r", **options, &block)
-      return to_enum(__method__, path, mode, **options) unless block_given?
-      open(path, mode, **options) do |csv|
+    def foreach(filename_or_io, mode="r", **options, &block)
+      return to_enum(__method__, filename_or_io, mode, **options) unless block_given?
+      open(filename_or_io, mode, **options) do |csv|
         csv.each(&block)
       end
     end
@@ -1565,8 +1565,8 @@ class CSV
 
     #
     # :call-seq:
-    #   open(path_or_io, mode = "rb", **options ) -> new_csv
-    #   open(path_or_io, mode = "rb", **options ) { |csv| ... } -> object
+    #   open(filename_or_io, mode = "rb", **options ) -> new_csv
+    #   open(filename_or_io, mode = "rb", **options ) { |csv| ... } -> object
     #
     # possible options elements:
     #   keyword form:
@@ -1575,14 +1575,14 @@ class CSV
     #     :undef => :replace   # replace undefined conversion
     #     :replace => string   # replacement string ("?" or "\uFFFD" if not specified)
     #
-    # * Argument +path_or_io+, must be a file path or an \IO stream.
+    # * Argument +filename_or_io+, must be a file path or an \IO stream.
     # :include: ../doc/csv/arguments/io.rdoc
     # * Argument +mode+, if given, must be a \File mode.
     #   See {Access Modes}[https://docs.ruby-lang.org/en/master/File.html#class-File-label-Access+Modes].
     # * Arguments <tt>**options</tt> must be keyword options.
     #   See {Options for Generating}[#class-CSV-label-Options+for+Generating].
     # * This method optionally accepts an additional <tt>:encoding</tt> option
-    #   that you can use to specify the Encoding of the data read from +path+ or +io+.
+    #   that you can use to specify the Encoding of the data read from +filename_or_io+.
     #   You must provide this unless your data is in the encoding
     #   given by <tt>Encoding::default_external</tt>.
     #   Parsing will use this to determine how to parse the data.
@@ -1919,16 +1919,16 @@ class CSV
     #   path = 't.csv'
     #   File.write(path, string)
     #   CSV.read(path, headers: true) # => #<CSV::Table mode:col_or_row row_count:4>
-    def read(path, **options)
-      open(path, **options) { |csv| csv.read }
+    def read(filename_or_io, **options)
+      open(filename_or_io, **options) { |csv| csv.read }
     end
 
     # :call-seq:
     #   CSV.readlines(source, **options)
     #
     # Alias for CSV.read.
-    def readlines(path, **options)
-      read(path, **options)
+    def readlines(filename_or_io, **options)
+      read(filename_or_io, **options)
     end
 
     # :call-seq:
@@ -1946,14 +1946,14 @@ class CSV
     #   path = 't.csv'
     #   File.write(path, string)
     #   CSV.table(path) # => #<CSV::Table mode:col_or_row row_count:4>
-    def table(path, **options)
+    def table(filename_or_io, **options)
       default_options = {
         headers:           true,
         converters:        :numeric,
         header_converters: :symbol,
       }
       options = default_options.merge(options)
-      read(path, **options)
+      read(filename_or_io, **options)
     end
 
     ON_WINDOWS = /mingw|mswin/.match?(RUBY_PLATFORM)

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1302,10 +1302,10 @@ class CSV
 
     #
     # :call-seq:
-    #   foreach(filename_or_io, mode='r', **options) {|row| ... )
-    #   foreach(filename_or_io, mode='r', **options) -> new_enumerator
+    #   foreach(path_or_io, mode='r', **options) {|row| ... )
+    #   foreach(path_or_io, mode='r', **options) -> new_enumerator
     #
-    # Calls the block with each row read from source +filename_or_io+.
+    # Calls the block with each row read from source +path_or_io+.
     #
     # \Path input without headers:
     #
@@ -1371,7 +1371,7 @@ class CSV
     #   CSV.foreach(path) # => #<Enumerator: CSV:foreach("t.csv", "r")>
     #
     # Arguments:
-    # * Argument +filename_or_io+ must be a file path or an \IO stream.
+    # * Argument +path_or_io+ must be a file path or an \IO stream.
     # * Argument +mode+, if given, must be a \File mode.
     #   See {Access Modes}[https://docs.ruby-lang.org/en/master/File.html#class-File-label-Access+Modes].
     # * Arguments <tt>**options</tt> must be keyword options.
@@ -1386,9 +1386,9 @@ class CSV
     #     encoding: 'UTF-32BE:UTF-8'
     #   would read +UTF-32BE+ data from the file
     #   but transcode it to +UTF-8+ before parsing.
-    def foreach(filename_or_io, mode="r", **options, &block)
-      return to_enum(__method__, filename_or_io, mode, **options) unless block_given?
-      open(filename_or_io, mode, **options) do |csv|
+    def foreach(path_or_io, mode="r", **options, &block)
+      return to_enum(__method__, path_or_io, mode, **options) unless block_given?
+      open(path_or_io, mode, **options) do |csv|
         csv.each(&block)
       end
     end
@@ -1565,8 +1565,8 @@ class CSV
 
     #
     # :call-seq:
-    #   open(filename_or_io, mode = "rb", **options ) -> new_csv
-    #   open(filename_or_io, mode = "rb", **options ) { |csv| ... } -> object
+    #   open(path_or_io, mode = "rb", **options ) -> new_csv
+    #   open(path_or_io, mode = "rb", **options ) { |csv| ... } -> object
     #
     # possible options elements:
     #   keyword form:
@@ -1575,14 +1575,14 @@ class CSV
     #     :undef => :replace   # replace undefined conversion
     #     :replace => string   # replacement string ("?" or "\uFFFD" if not specified)
     #
-    # * Argument +filename_or_io+, must be a file path or an \IO stream.
+    # * Argument +path_or_io+, must be a file path or an \IO stream.
     # :include: ../doc/csv/arguments/io.rdoc
     # * Argument +mode+, if given, must be a \File mode.
     #   See {Access Modes}[https://docs.ruby-lang.org/en/master/File.html#class-File-label-Access+Modes].
     # * Arguments <tt>**options</tt> must be keyword options.
     #   See {Options for Generating}[#class-CSV-label-Options+for+Generating].
     # * This method optionally accepts an additional <tt>:encoding</tt> option
-    #   that you can use to specify the Encoding of the data read from +filename_or_io+.
+    #   that you can use to specify the Encoding of the data read from +path_or_io+.
     #   You must provide this unless your data is in the encoding
     #   given by <tt>Encoding::default_external</tt>.
     #   Parsing will use this to determine how to parse the data.
@@ -1644,11 +1644,11 @@ class CSV
     # Raises an exception if the argument is not a \String object or \IO object:
     #   # Raises TypeError (no implicit conversion of Symbol into String)
     #   CSV.open(:foo)
-    def open(filename_or_io, mode="r", **options)
+    def open(path_or_io, mode="r", **options)
       # wrap a File opened with the remaining +args+ with no newline
       # decorator
       file_opts = {}
-      may_enable_bom_detection_automatically(filename_or_io,
+      may_enable_bom_detection_automatically(path_or_io,
                                              mode,
                                              options,
                                              file_opts)
@@ -1661,11 +1661,11 @@ class CSV
       options.delete(:replace)
       options.delete_if {|k, _| /newline\z/.match?(k)}
 
-      if filename_or_io.is_a?(StringIO)
-        f = create_stringio(filename_or_io.string, mode, **file_opts)
+      if path_or_io.is_a?(StringIO)
+        f = create_stringio(path_or_io.string, mode, **file_opts)
       else
         begin
-          f = File.open(filename_or_io, mode, **file_opts)
+          f = File.open(path_or_io, mode, **file_opts)
         rescue ArgumentError => e
           raise unless /needs binmode/.match?(e.message) and mode == "r"
           mode = "rb"
@@ -1919,16 +1919,16 @@ class CSV
     #   path = 't.csv'
     #   File.write(path, string)
     #   CSV.read(path, headers: true) # => #<CSV::Table mode:col_or_row row_count:4>
-    def read(filename_or_io, **options)
-      open(filename_or_io, **options) { |csv| csv.read }
+    def read(path_or_io, **options)
+      open(path_or_io, **options) { |csv| csv.read }
     end
 
     # :call-seq:
     #   CSV.readlines(source, **options)
     #
     # Alias for CSV.read.
-    def readlines(filename_or_io, **options)
-      read(filename_or_io, **options)
+    def readlines(path_or_io, **options)
+      read(path_or_io, **options)
     end
 
     # :call-seq:
@@ -1946,25 +1946,25 @@ class CSV
     #   path = 't.csv'
     #   File.write(path, string)
     #   CSV.table(path) # => #<CSV::Table mode:col_or_row row_count:4>
-    def table(filename_or_io, **options)
+    def table(path_or_io, **options)
       default_options = {
         headers:           true,
         converters:        :numeric,
         header_converters: :symbol,
       }
       options = default_options.merge(options)
-      read(filename_or_io, **options)
+      read(path_or_io, **options)
     end
 
     ON_WINDOWS = /mingw|mswin/.match?(RUBY_PLATFORM)
     private_constant :ON_WINDOWS
 
     private
-    def may_enable_bom_detection_automatically(filename_or_io,
+    def may_enable_bom_detection_automatically(path_or_io,
                                                mode,
                                                options,
                                                file_opts)
-      if filename_or_io.is_a?(StringIO)
+      if path_or_io.is_a?(StringIO)
         # Support to StringIO was dropped for Ruby 2.6 and earlier without BOM support:
         # https://github.com/ruby/stringio/pull/47
         return if RUBY_VERSION < "2.7"

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1901,10 +1901,10 @@ class CSV
 
     #
     # :call-seq:
-    #   read(source, **options) -> array_of_arrays
-    #   read(source, headers: true, **options) -> csv_table
+    #   read(path_or_io, **options) -> array_of_arrays
+    #   read(path_or_io, headers: true, **options) -> csv_table
     #
-    # Opens the given +source+ with the given +options+ (see CSV.open),
+    # Opens the given +path_or_io+ with the given +options+ (see CSV.open),
     # reads the source (see CSV#read), and returns the result,
     # which will be either an \Array of Arrays or a CSV::Table.
     #
@@ -1924,7 +1924,7 @@ class CSV
     end
 
     # :call-seq:
-    #   CSV.readlines(source, **options)
+    #   CSV.readlines(path_or_io, **options)
     #
     # Alias for CSV.read.
     def readlines(path_or_io, **options)
@@ -1932,9 +1932,9 @@ class CSV
     end
 
     # :call-seq:
-    #   CSV.table(source, **options)
+    #   CSV.table(path_or_io, **options)
     #
-    # Calls CSV.read with +source+, +options+, and certain default options:
+    # Calls CSV.read with +path_or_io+, +options+, and certain default options:
     # - +headers+: +true+
     # - +converters+: +:numeric+
     # - +header_converters+: +:symbol+


### PR DESCRIPTION
## Overview

Previously, the first parameter name was inconsistent across methods and their RDoc comments, with names such as `path`, `source`, and `filename_or_io` used interchangeably despite referring to the same concept:
a file path or an IO object.

This change aligns all class methods to use `path_or_io`. This more accurately conveys that the argument accepts either a file path or an IO object.

## Reference

- https://github.com/ruby/csv/pull/302